### PR TITLE
Cast ByteBuffer objects when calling invalid Java9 methods

### DIFF
--- a/src/main/java/gov/nasa/pds/objectAccess/ByteWiseFileAccessor.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/ByteWiseFileAccessor.java
@@ -38,6 +38,7 @@ import java.io.FileInputStream;
 import java.io.RandomAccessFile;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.Channels;
@@ -256,7 +257,7 @@ public class ByteWiseFileAccessor {
 	      byte[] bufPortion1 = new byte[aBuf.remaining()];
           aBuf.get(bufPortion1);
           aBuf = this.mappings.get(mapN+1);                                             // Get the next mapping.
-          aBuf.position(0);                                                        // Point the position to the beginning.
+          ((Buffer) aBuf).position(0);                                                        // Point the position to the beginning.
           byte[] bufPortion2 = new byte[this.recordLength-bufPortion1.length]; // The second portion size is the difference.
           aBuf.get(bufPortion2);                                                 // Get the 2nd portion of record from next mapping.
 
@@ -302,7 +303,7 @@ public class ByteWiseFileAccessor {
 	  }
 
 	  ByteBuffer aBuf = mappings.get(mapN);
-	  aBuf.position(offN);   // need to check this
+	  ((Buffer) aBuf).position(offN);   // need to check this
 
       // It is possible to read pass the buffer in variable 'buf'.  Perform a check before the get() function.
       // If not enough bytes left in the buffer, that means that the record we are reading is spanning the boundary of two
@@ -354,7 +355,7 @@ public class ByteWiseFileAccessor {
 	 */
   public void mark() {
 	  int mapN = (int)(this.curPosition/MAPPING_SIZE);
-	  mappings.get(mapN).mark();
+	  ((Buffer) mappings.get(mapN)).mark();
 	}
 	
 	/**
@@ -364,7 +365,7 @@ public class ByteWiseFileAccessor {
   public void reset() {
 	  // reset all buffer??
 	  for (int i=0; i<mappings.size(); i++)
-	    mappings.get(i).reset();
+	    ((Buffer) mappings.get(i)).reset();
 	}
 	
 	/**

--- a/src/main/java/gov/nasa/pds/objectAccess/FixedTableRecord.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/FixedTableRecord.java
@@ -38,6 +38,7 @@ import gov.nasa.pds.objectAccess.table.DefaultFieldAdapter;
 import gov.nasa.pds.objectAccess.table.DelimiterType;
 
 import java.math.BigInteger;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -86,7 +87,7 @@ public class FixedTableRecord implements TableRecord {
 
 			// Set the buffer position based on the length of the record delimiter
 			// and add the delimiter at that position to the end of the record.
-			this.buffer.position(length - delimiter.getBytes(charset).length);
+			((Buffer) this.buffer).position(length - delimiter.getBytes(charset).length);
 			setString(delimiter);
 		}
 	}
@@ -336,7 +337,7 @@ public class FixedTableRecord implements TableRecord {
 
 	@Override
 	public void clear() {
-		buffer.clear();
+		((Buffer) buffer).clear();
 	}
 
 	/**

--- a/src/main/java/gov/nasa/pds/objectAccess/array/ArrayAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/array/ArrayAdapter.java
@@ -31,6 +31,7 @@
 package gov.nasa.pds.objectAccess.array;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 
@@ -260,7 +261,7 @@ public class ArrayAdapter {
 	       cachedBuffer = buf;
 	     } else {
 	       int relativePosition = (int) (index - startPosition);
-	       buf.position(relativePosition);
+	       ((Buffer) buf).position(relativePosition);
 	     }
 	     return buf;
 	  }
@@ -283,7 +284,7 @@ public class ArrayAdapter {
 	      buf = ByteBuffer.allocate(BUFFER_SIZE);
 	    }
 	    channel.read(buf);
-	    buf.flip();
+	    ((Buffer) buf).flip();
 	    startPosition = index;
 	    return buf;
 	  }

--- a/src/main/java/gov/nasa/pds/objectAccess/table/DefaultFieldAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/DefaultFieldAdapter.java
@@ -31,6 +31,7 @@
 package gov.nasa.pds.objectAccess.table;
 
 import java.math.BigInteger;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
@@ -126,7 +127,7 @@ public class DefaultFieldAdapter implements FieldAdapter {
 		if (value.length() > length) {
 			throw new IllegalArgumentException("The size of the value is greater than the field length.");
 		}
-		buffer.position(offset);
+		((Buffer) buffer).position(offset);
 		buffer.put(getJustifiedValue(value, length, isRightJustified, charset), 0, length);
 	}
 

--- a/src/main/java/gov/nasa/pds/objectAccess/table/IntegerBinaryFieldAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/IntegerBinaryFieldAdapter.java
@@ -31,6 +31,7 @@
 package gov.nasa.pds.objectAccess.table;
 
 import java.math.BigInteger;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
@@ -121,7 +122,7 @@ public class IntegerBinaryFieldAdapter implements FieldAdapter {
 			throw new IllegalArgumentException("The size of the value is greater than the field length.");
 		}
 		buffer.order(isBigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN);
-		buffer.position(offset);
+		((Buffer) buffer).position(offset);
 		buffer.put(value.getBytes(charset), 0, length);
 	}
 
@@ -303,7 +304,7 @@ public class IntegerBinaryFieldAdapter implements FieldAdapter {
 			if (isSigned && b[0] < 0) {
 				Arrays.fill(temp, (byte) 0xFF);
 			}
-			buffer.position(offset);
+			((Buffer) buffer).position(offset);
 			buffer.put(temp);
 		}
 

--- a/src/test/java/gov/nasa/pds/objectAccess/array/DoubleAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/array/DoubleAdapterTest.java
@@ -30,6 +30,7 @@
 
 package gov.nasa.pds.objectAccess.array;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import org.testng.annotations.DataProvider;
@@ -67,11 +68,11 @@ public class DoubleAdapterTest {
 		ByteBuffer buf = ByteBuffer.wrap(bytes);
 		DoubleAdapter adapter = new DoubleAdapter(isBigEndian);
 		
-		buf.rewind();
+		((Buffer) buf).rewind();
 		assertEquals(adapter.getDouble(buf), (double) value);
-		buf.rewind();
+		((Buffer) buf).rewind();
 		assertEquals(adapter.getInt(buf), (int) value);
-		buf.rewind();
+		((Buffer) buf).rewind();
 		assertEquals(adapter.getLong(buf), (long) value);
 	}
 	

--- a/src/test/java/gov/nasa/pds/objectAccess/array/FloatAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/array/FloatAdapterTest.java
@@ -30,6 +30,7 @@
 
 package gov.nasa.pds.objectAccess.array;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import org.testng.annotations.DataProvider;
@@ -63,11 +64,11 @@ public class FloatAdapterTest {
 		ByteBuffer buf = ByteBuffer.wrap(bytes);
 		FloatAdapter adapter = new FloatAdapter(isBigEndian);
 		
-		buf.rewind();
+		((Buffer) buf).rewind();
 		assertEquals(adapter.getDouble(buf), (double) value);
-		buf.rewind();
+		((Buffer) buf).rewind();
 		assertEquals(adapter.getInt(buf), (int) value);
-		buf.rewind();
+		((Buffer) buf).rewind();
 		assertEquals(adapter.getLong(buf), (long) value);
 	}
 	

--- a/src/test/java/gov/nasa/pds/objectAccess/array/IntegerAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/array/IntegerAdapterTest.java
@@ -33,6 +33,7 @@ package gov.nasa.pds.objectAccess.array;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import org.testng.annotations.DataProvider;
@@ -51,16 +52,16 @@ public class IntegerAdapterTest {
 		IntegerAdapter adapter = new IntegerAdapter(data.length, isBigEndian, isUnsigned);
 		
 		assertEquals(adapter.getLong(buf), expected);
-		buf.rewind();
+		((Buffer) buf).rewind();
 		assertEquals(adapter.getDouble(buf), (double) expected);
 		
 		if (Integer.MIN_VALUE<=expected && expected<=Integer.MAX_VALUE) {
-			buf.rewind();
+		    ((Buffer) buf).rewind();
 			int actualInt = adapter.getInt(buf);
 			assertEquals(actualInt, (int) expected);
 		} else {
 			try {
-				buf.rewind();
+			    ((Buffer) buf).rewind();
 				@SuppressWarnings("unused")
 				int actualInt = adapter.getInt(buf);
 				// If we get here, we didn't get an exception - fail

--- a/src/test/java/gov/nasa/pds/objectAccess/table/DefaultFieldAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/DefaultFieldAdapterTest.java
@@ -32,6 +32,7 @@ package gov.nasa.pds.objectAccess.table;
 
 import static org.testng.Assert.assertEquals;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
@@ -124,11 +125,11 @@ public class DefaultFieldAdapterTest {
 		int len = 5;
 		String s = "hello";
 		byte[] bytes = new byte[len];
-		buffer.clear(); // sets the buffer position to 0		
+		((Buffer) buffer).clear(); // sets the buffer position to 0		
 		adapter.setString(s, 0, len, buffer, false);
-		assertEquals(buffer.position(), len);
+		assertEquals(((Buffer) buffer).position(), len);
 		
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, len);			
 		assertEquals(bytes, s.getBytes(US_ASCII));				
 	}
@@ -137,9 +138,9 @@ public class DefaultFieldAdapterTest {
 	public void testRightJustified() {
 		int len = 7;		
 		byte[] bytes = new byte[len];		
-		buffer.clear(); 				
+		((Buffer) buffer).clear(); 				
 		adapter.setString("12345", 0, len, buffer, true);		
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, len);
 		
 		assertEquals(bytes, "  12345".getBytes(US_ASCII));
@@ -149,9 +150,9 @@ public class DefaultFieldAdapterTest {
 	public void testLeftJustified() {
 		int len = 7;		
 		byte[] bytes = new byte[len];		
-		buffer.clear(); 				
+		((Buffer) buffer).clear(); 				
 		adapter.setString("hello", 0, len, buffer, false);		
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, len);
 		
 		assertEquals(bytes, "hello  ".getBytes(US_ASCII));

--- a/src/test/java/gov/nasa/pds/objectAccess/table/DoubleBinaryFieldAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/DoubleBinaryFieldAdapterTest.java
@@ -32,6 +32,7 @@ package gov.nasa.pds.objectAccess.table;
 
 import static org.testng.Assert.assertEquals;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
@@ -101,13 +102,13 @@ public class DoubleBinaryFieldAdapterTest {
 		byte[] b = longToBytes(Double.doubleToLongBits(value), true);
 		FieldAdapter adapter = new DoubleBinaryFieldAdapter(true);					
 		adapter.setDouble(value, offset, length, buf, false);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 		
 		b = longToBytes(Double.doubleToLongBits((float) value), true);
 		adapter.setFloat((float) value, offset, length, buf, false);	
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}
@@ -120,13 +121,13 @@ public class DoubleBinaryFieldAdapterTest {
 		byte[] b = longToBytes(Double.doubleToLongBits(value), false);
 		FieldAdapter adapter = new DoubleBinaryFieldAdapter(false);		
 		adapter.setDouble(value, offset, length, buf, false);	
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);				
 		assertEquals(bytes, b);
 		
 		b = longToBytes(Double.doubleToLongBits((float) value), false);
 		adapter.setFloat((float) value, offset, length, buf, false);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}
@@ -146,15 +147,15 @@ public class DoubleBinaryFieldAdapterTest {
 		};
 		int length = Double.SIZE / Byte.SIZE;
 		byte[] bytes = new byte[length];
-		buffer.clear();
+		((Buffer) buffer).clear();
 		FieldAdapter adapter = new DoubleBinaryFieldAdapter(true);		
 		adapter.setString(Double.toString(3.14), 0, length, buffer, true);
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, length);
 		assertEquals(bytes, b);
 		
 		adapter.setString(Double.toString(3.14), 0, length, buffer, true, Charset.forName("US-ASCII"));
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, length);
 		assertEquals(bytes, b);		
 	}

--- a/src/test/java/gov/nasa/pds/objectAccess/table/FloatBinaryFieldAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/FloatBinaryFieldAdapterTest.java
@@ -32,6 +32,7 @@ package gov.nasa.pds.objectAccess.table;
 
 import static org.testng.Assert.assertEquals;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
@@ -126,12 +127,12 @@ public class FloatBinaryFieldAdapterTest {
 		FieldAdapter adapter = new FloatBinaryFieldAdapter(true);
 		
 		adapter.setFloat(value, offset, length, buf, false);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 				
 		adapter.setDouble((double) value, offset, length, buf, false);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}
@@ -145,12 +146,12 @@ public class FloatBinaryFieldAdapterTest {
 		FieldAdapter adapter = new FloatBinaryFieldAdapter(false);
 		
 		adapter.setFloat(value, offset, length, buf, false);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);		
 		assertEquals(bytes, b);
 		
 		adapter.setDouble((double) value, offset, length, buf, false);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}

--- a/src/test/java/gov/nasa/pds/objectAccess/table/IntegerBinaryFieldAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/IntegerBinaryFieldAdapterTest.java
@@ -33,6 +33,7 @@ package gov.nasa.pds.objectAccess.table;
 import static org.testng.Assert.assertEquals;
 
 import java.math.BigInteger;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import org.testng.annotations.DataProvider;
@@ -163,13 +164,13 @@ public class IntegerBinaryFieldAdapterTest {
 		byte[] bytes = new byte[len];
 		FieldAdapter adapter = new IntegerBinaryFieldAdapter(len, true, true);
 		adapter.setString(s, 0, len, buffer, true);
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, len);
 		assertEquals(bytes, s.getBytes("US-ASCII"));
 
 		adapter = new IntegerBinaryFieldAdapter(len, true, false);
 		adapter.setString(s, 10, len, buffer, true);
-		buffer.position(10);
+		((Buffer) buffer).position(10);
 		buffer.get(bytes, 0, len);
 		assertEquals(bytes, s.getBytes("US-ASCII"));
 	}
@@ -180,7 +181,7 @@ public class IntegerBinaryFieldAdapterTest {
 		ByteBuffer buf = ByteBuffer.allocate(20);
 		FieldAdapter adapter = new IntegerBinaryFieldAdapter(length, true, isBigEndian);
 		adapter.setLong(value, offset, length, buf, true);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}
@@ -199,7 +200,7 @@ public class IntegerBinaryFieldAdapterTest {
 		ByteBuffer buf = ByteBuffer.allocate(20);
 		FieldAdapter adapter = new IntegerBinaryFieldAdapter(length, true, isBigEndian);
 		adapter.setInt((int) value, offset, length, buf, true);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}
@@ -218,7 +219,7 @@ public class IntegerBinaryFieldAdapterTest {
 		ByteBuffer buf = ByteBuffer.allocate(20);
 		FieldAdapter adapter = new IntegerBinaryFieldAdapter(length, true, isBigEndian);
 		adapter.setShort((short) value, offset, length, buf, true);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}
@@ -229,7 +230,7 @@ public class IntegerBinaryFieldAdapterTest {
 		ByteBuffer buf = ByteBuffer.allocate(20);
 		FieldAdapter adapter = new IntegerBinaryFieldAdapter(length, true, isBigEndian);
 		adapter.setByte((byte) value, offset, length, buf, true);
-		buf.position(offset);
+		((Buffer) buf).position(offset);
 		buf.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}

--- a/src/test/java/gov/nasa/pds/objectAccess/table/NumericTextFieldAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/NumericTextFieldAdapterTest.java
@@ -32,6 +32,7 @@ package gov.nasa.pds.objectAccess.table;
 
 import static org.testng.Assert.assertEquals;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
@@ -136,20 +137,20 @@ public class NumericTextFieldAdapterTest {
 		byte[] b = Integer.toString(value).getBytes(US_ASCII);
 		int length = b.length;
 		byte[] bytes = new byte[length];		
-		buffer.clear();
+		((Buffer) buffer).clear();
 		
 		adapter.setInt(value, 0, length, buffer, false);		
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, length);
 		assertEquals(bytes, b);
 				
 		adapter.setShort((short) value, 5, length, buffer, false);		
-		buffer.position(5);
+		((Buffer) buffer).position(5);
 		buffer.get(bytes, 0, length);
 		assertEquals(bytes, b);
 				
 		adapter.setByte((byte) value, 10, length, buffer, false);		
-		buffer.position(10);
+		((Buffer) buffer).position(10);
 		buffer.get(bytes, 0, length);
 		assertEquals(bytes, b);		
 	}
@@ -160,9 +161,9 @@ public class NumericTextFieldAdapterTest {
 		byte[] b = Long.toString(value).getBytes(US_ASCII);
 		int length = b.length;
 		byte[] bytes = new byte[length];		
-		buffer.clear();		
+		((Buffer) buffer).clear();		
 		adapter.setLong(value, 0, length, buffer, false);		
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, length);
 		assertEquals(bytes, b);
 	}
@@ -173,9 +174,9 @@ public class NumericTextFieldAdapterTest {
 		byte[] b = Float.toString(value).getBytes(US_ASCII);
 		int length = b.length;
 		byte[] bytes = new byte[length];
-		buffer.clear();		
+		((Buffer) buffer).clear();		
 		adapter.setFloat(value, 0, length, buffer, false);		
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, length);			
 		assertEquals(bytes, b);
 	}
@@ -186,9 +187,9 @@ public class NumericTextFieldAdapterTest {
 		byte[] b = Double.toString(value).getBytes(US_ASCII);		
 		int length = b.length;
 		byte[] bytes = new byte[length];
-		buffer.clear();
+		((Buffer) buffer).clear();
 		adapter.setDouble(value, 0, length, buffer, false);		
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		buffer.get(bytes, 0, length);		
 		assertEquals(bytes, b);	
 	}


### PR DESCRIPTION
for example: ((Buffer)byteBuffer).position(0);

resolves #36

**Test Data and/or Report**
Unit tests completed successfully. Also tested and built with validate successfully.
