### PR TITLE
Allows the counting of number of records in large file

### DIFF
--- a/src/main/java/gov/nasa/pds/objectAccess/TableReader.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/TableReader.java
@@ -53,14 +53,11 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
-//import java.util.stream.Collectors;
 import java.net.URLConnection;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
-//import java.util.stream.Collectors;
-//import java.util.Scanner;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -318,11 +315,6 @@ public class TableReader {
         // Count the number of carriage returns for a file of any size.   The traditional BufferReader cannot handle files larger than 2GB.
         long numCarriageReturns = 0;
 
-        //offset = 0;
-        //System.out.print("offset ");
-        //System.out.println(offset);
-        //System.exit(0);
-
         // Use RandomAccessFile to get filesize larger than 2gb
         File aFile = new File(dataFile.toURI());
         RandomAccessFile raf = new RandomAccessFile(aFile, "r");
@@ -343,22 +335,13 @@ public class TableReader {
         while (inChannel.read(buff) > 0) {
             buff = buff.position(0); // Must point the pointer to the beginning of buff indorder to access the elements in the array.
             text = charset.decode(buff).toString();
-//System.out.print("text  [");
-//System.out.print(text);
-//System.out.println("]");
         
             // After the byte array is converted to text, we can look for the carriage returns.
             while ((fromIndex = text.indexOf(strFind, fromIndex)) != -1 ){
-//System.out.println("Found at index: " + fromIndex);
-//System.out.print(".");
                 numCarriageReturns++;
                 fromIndex++;
-//System.out.println("numCarriageReturns: " + numCarriageReturns);
              }
              buff.clear();
-        
-//System.out.println("Total occurrences: " + numCarriageReturns);
-//System.exit(0);
         }
         raf.close();
         return(numCarriageReturns);

--- a/src/main/java/gov/nasa/pds/objectAccess/TableReader.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/TableReader.java
@@ -332,9 +332,9 @@ public class TableReader {
         return linesInBuffer;
     }
 
-    private long countCarriageReturn(URL dataFile) throws Exception {
-        // Count the number of carriage returns for a file of any size.   The traditional BufferReader cannot handle files larger than 2GB.
-        long numCarriageReturns = 0;
+    private long countRecordsForTextTable(URL dataFile) throws Exception {
+        // Count the number of records for a text file of any size.   The traditional BufferReader cannot handle files larger than 2GB.
+        long numRecordsForTextTable = 0;
 
         // Use RandomAccessFile to get filesize larger than 2gb
         File aFile = new File(dataFile.toURI());
@@ -354,12 +354,12 @@ public class TableReader {
             bufferAsBytes = buff.array();  // Get the underlying byte array in ByteBuffer.
 
              // With the smaller buffer, we can safely read through the buffer for all lines and count them.
-             numCarriageReturns = numCarriageReturns + this.parseBufferForLineCount(dataFile, bufferAsBytes);
+             numRecordsForTextTable = numRecordsForTextTable + this.parseBufferForLineCount(dataFile, bufferAsBytes);
 
              buff.clear();
         }
         raf.close();
-        return(numCarriageReturns);
+        return(numRecordsForTextTable);
     }
 
     private long countRecordsForTableAdapterType(URL dataFile, long offset) throws Exception {
@@ -372,10 +372,10 @@ public class TableReader {
         long numRecords = -1;
 
         // Do a sanity check if the record size is not known or zero.  Not all labels provide the record size, for example comma separated files.
-        // If the record size is not known or zero, unfortunately we must read through the file and count the carriage returns.
+        // If the record size is not known or zero, unfortunately we must read through the file and count the records.
 
         if (adapter.getRecordLength() <= 0) {
-            numRecords = this.countCarriageReturn(dataFile);
+            numRecords = this.countRecordsForTextTable(dataFile);
             LOGGER.debug("countRecordsForTableAdapterType:numRecords {}",numRecords);
             return(numRecords);
         }


### PR DESCRIPTION
* Modify logic to count the number of records in a large file in TableReader.java
Refs:

https://github.com/NASA-PDS/validate/issues#326 File-size check fails for large data files
https://github.com/NASA-PDS/validate/issues#327 validate fails to process large data file

The testing will be done via validate pull request which uses the service of TableReader.java
This pull request should be merged before validate since there is a dependency.