### PR TITLE
Update branch CICD to use integration assembly

### DIFF
--- a/.github/workflows/branch-cicd.yml
+++ b/.github/workflows/branch-cicd.yml
@@ -48,7 +48,7 @@ jobs:
                 uses: NASA-PDS/roundup-action@main
                 with:
                     assembly: integration
-                    packages: ${{ matrix.java-version }}
+                    packages: ${{ matrix.openjdk-version }}
                 env:
                     ossrh_username: ${{secrets.OSSRH_USERNAME}}
                     ossrh_password: ${{secrets.OSSRH_PASSWORD}}

--- a/.github/workflows/branch-cicd.yml
+++ b/.github/workflows/branch-cicd.yml
@@ -49,6 +49,7 @@ jobs:
                 with:
                     assembly: integration
                     packages: ${{ matrix.openjdk-version }}
+                    maven-unstable-artifact-phases: clean,package,site
                 env:
                     ossrh_username: ${{secrets.OSSRH_USERNAME}}
                     ossrh_password: ${{secrets.OSSRH_PASSWORD}}

--- a/.github/workflows/branch-cicd.yml
+++ b/.github/workflows/branch-cicd.yml
@@ -33,20 +33,24 @@ jobs:
 
         strategy:
           matrix:
-            java-version: [8, 11]
+            openjdk-version: [ openjdk8, openjdk11 ]
 
         steps:
-          - uses: actions/checkout@v2
-          - name: Set up OpenJDK
-            uses: actions/setup-java@v2
-            with:
-              distribution: 'adopt'
-              java-version: ${{ matrix.java-version }}
+            -
+                name: 💳 Checkout
+                uses: actions/checkout@v2
+                with:
+                    lfs: true
+                    token: ${{secrets.ADMIN_GITHUB_TOKEN}}
 
-          - name: Test Software
-            run: mvn compile test site --file pom.xml
-            env:
-               MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-               MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-
-# -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-
+            -
+                name: 🤠 Roundup
+                uses: NASA-PDS/roundup-action@main
+                with:
+                    assembly: integration
+                    packages: ${{ matrix.java-version }}
+                env:
+                    ossrh_username: ${{secrets.OSSRH_USERNAME}}
+                    ossrh_password: ${{secrets.OSSRH_PASSWORD}}
+                    CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
+                    ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}


### PR DESCRIPTION
**Summary***
Update branch CICD to use integration assembly + test out NASA-PDS/roundup-action#42 to check if we use openjdk11

**Test Data and/or Report**
See Github Action checks. Will add snippet to prove closure of roundup ticket or if the updates are not sufficient

**Related Issues**
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->