### PR TITLE
Update FieldDescription to include SpecialConstants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <dependency>
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
       <exclusions>
         <exclusion>
           <groupId>xml-apis</groupId>

--- a/src/main/java/gov/nasa/pds/label/object/FieldDescription.java
+++ b/src/main/java/gov/nasa/pds/label/object/FieldDescription.java
@@ -30,6 +30,7 @@
 
 package gov.nasa.pds.label.object;
 
+import gov.nasa.arc.pds.xml.generated.SpecialConstants;
 
 /**
  * Implements a description of a table field.
@@ -47,6 +48,7 @@ public class FieldDescription {
 	private String validationFormat;
 	private Double minimum;
 	private Double maximum;
+	private SpecialConstants specialConstants;
 	
 	public FieldDescription() {
 	  name = "";
@@ -60,9 +62,11 @@ public class FieldDescription {
 	  validationFormat = "";
 	  minimum = null;
 	  maximum = null;
+	  specialConstants = null;
 	}
 	
-	/**
+
+  /**
 	 * Gets the field name.
 	 * 
 	 * @return the field name
@@ -228,5 +232,13 @@ public class FieldDescription {
 	public Double getMaximum() {
 	  return maximum;
 	}
+
+	public SpecialConstants getSpecialConstants() {
+	  return specialConstants;
+	}
+
+    public void setSpecialConstants(SpecialConstants specialConstants) {
+      this.specialConstants = specialConstants;
+    }
 	
 }

--- a/src/main/java/gov/nasa/pds/objectAccess/table/TableBinaryAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/TableBinaryAdapter.java
@@ -83,6 +83,7 @@ public class TableBinaryAdapter implements TableAdapter {
 		desc.setType(FieldType.getFieldType(field.getDataType()));
 		desc.setOffset(field.getFieldLocation().getValue().intValueExact() - 1 + baseOffset);
 		desc.setLength(field.getFieldLength().getValue().intValueExact());
+		desc.setSpecialConstants(field.getSpecialConstants());
     if (field.getFieldFormat() != null) {
       desc.setFieldFormat(field.getFieldFormat());
     }
@@ -116,6 +117,7 @@ public class TableBinaryAdapter implements TableAdapter {
 		desc.setType(FieldType.getFieldType(bitField.getDataType()));
 		desc.setOffset(field.getFieldLocation().getValue().intValueExact() - 1 + baseOffset);
 		desc.setLength(field.getFieldLength().getValue().intValueExact());
+		desc.setSpecialConstants(field.getSpecialConstants());
 		int startBit = 0;
 		if (bitField.getStartBit() != null) {
 		  startBit = bitField.getStartBit().intValueExact();

--- a/src/main/java/gov/nasa/pds/objectAccess/table/TableCharacterAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/TableCharacterAdapter.java
@@ -74,6 +74,7 @@ public class TableCharacterAdapter implements TableAdapter {
 		desc.setType(FieldType.getFieldType(field.getDataType()));
 		desc.setOffset(field.getFieldLocation().getValue().intValueExact() - 1 + baseOffset);
 		desc.setLength(field.getFieldLength().getValue().intValueExact());
+		desc.setSpecialConstants(field.getSpecialConstants());
     if (field.getFieldFormat() != null) {
       desc.setFieldFormat(field.getFieldFormat());
     }

--- a/src/main/java/gov/nasa/pds/objectAccess/table/TableDelimitedAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/TableDelimitedAdapter.java
@@ -71,6 +71,7 @@ public class TableDelimitedAdapter implements TableAdapter {
 		FieldDescription desc = new FieldDescription();
 		desc.setName(field.getName());
 		desc.setType(FieldType.getFieldType(field.getDataType()));
+		desc.setSpecialConstants(field.getSpecialConstants());
 		if (field.getMaximumFieldLength() != null) {
 		  desc.setMaxLength(field.getMaximumFieldLength().getValue().intValueExact());
 		}


### PR DESCRIPTION
When FieldDescription is used, we need to be able to access SpecialConstants so we can check if a value is one of the special constants before we check field statistics, like min/max/etc.

refs nasa-pds/validate#469
