### PR TITLE
Refactor to support more robust data object access

### DIFF
--- a/src/main/java/gov/nasa/pds/label/Label.java
+++ b/src/main/java/gov/nasa/pds/label/Label.java
@@ -36,25 +36,55 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import gov.nasa.arc.pds.xml.generated.Array;
 import gov.nasa.arc.pds.xml.generated.ByteStream;
+import gov.nasa.arc.pds.xml.generated.EncodedBinary;
 import gov.nasa.arc.pds.xml.generated.EncodedByteStream;
+import gov.nasa.arc.pds.xml.generated.EncodedNative;
+import gov.nasa.arc.pds.xml.generated.FileAreaAncillary;
+import gov.nasa.arc.pds.xml.generated.FileAreaBinary;
+import gov.nasa.arc.pds.xml.generated.FileAreaBrowse;
+import gov.nasa.arc.pds.xml.generated.FileAreaEncodedImage;
+import gov.nasa.arc.pds.xml.generated.FileAreaInventory;
 import gov.nasa.arc.pds.xml.generated.FileAreaMetadata;
+import gov.nasa.arc.pds.xml.generated.FileAreaNative;
 import gov.nasa.arc.pds.xml.generated.FileAreaObservational;
 import gov.nasa.arc.pds.xml.generated.FileAreaObservationalSupplemental;
+import gov.nasa.arc.pds.xml.generated.FileAreaSIPDeepArchive;
+import gov.nasa.arc.pds.xml.generated.FileAreaSPICEKernel;
+import gov.nasa.arc.pds.xml.generated.FileAreaServiceDescription;
+import gov.nasa.arc.pds.xml.generated.FileAreaText;
+import gov.nasa.arc.pds.xml.generated.FileAreaXMLSchema;
+import gov.nasa.arc.pds.xml.generated.InformationPackageComponent;
 import gov.nasa.arc.pds.xml.generated.ParsableByteStream;
 import gov.nasa.arc.pds.xml.generated.Product;
+import gov.nasa.arc.pds.xml.generated.ProductAIP;
+import gov.nasa.arc.pds.xml.generated.ProductAncillary;
+import gov.nasa.arc.pds.xml.generated.ProductBrowse;
+import gov.nasa.arc.pds.xml.generated.ProductCollection;
+import gov.nasa.arc.pds.xml.generated.ProductFileRepository;
+import gov.nasa.arc.pds.xml.generated.ProductFileText;
 import gov.nasa.arc.pds.xml.generated.ProductMetadataSupplemental;
+import gov.nasa.arc.pds.xml.generated.ProductNative;
 import gov.nasa.arc.pds.xml.generated.ProductObservational;
+import gov.nasa.arc.pds.xml.generated.ProductSIP;
+import gov.nasa.arc.pds.xml.generated.ProductSIPDeepArchive;
+import gov.nasa.arc.pds.xml.generated.ProductSPICEKernel;
+import gov.nasa.arc.pds.xml.generated.ProductService;
+import gov.nasa.arc.pds.xml.generated.ProductThumbnail;
+import gov.nasa.arc.pds.xml.generated.ProductXMLSchema;
+import gov.nasa.arc.pds.xml.generated.ServiceDescription;
 import gov.nasa.arc.pds.xml.generated.TableBinary;
 import gov.nasa.arc.pds.xml.generated.TableCharacter;
 import gov.nasa.arc.pds.xml.generated.TableDelimited;
 import gov.nasa.pds.label.object.ArrayObject;
 import gov.nasa.pds.label.object.DataObject;
+import gov.nasa.pds.label.object.DataObjectLocation;
 import gov.nasa.pds.label.object.GenericObject;
 import gov.nasa.pds.label.object.TableObject;
 import gov.nasa.pds.objectAccess.ObjectAccess;
@@ -220,43 +250,163 @@ public class Label {
 
 
   private List<DataObject> getDataObjects(Product product) throws Exception {
-    if (product instanceof ProductObservational) {
-      return getDataObjects((ProductObservational) product);
-    }
-    if (product instanceof ProductMetadataSupplemental) {
+    if (product instanceof ProductAIP) {
+      return getDataObjects((ProductAIP) product);
+    } else if (product instanceof ProductAncillary) {
+      return getDataObjects((ProductAncillary) product);
+    } else if (product instanceof ProductBrowse) {
+      return getDataObjects((ProductBrowse) product);
+      // } else if (product instanceof ProductBundle) {
+      // return getDataObjects((ProductBundle) product);
+    } else if (product instanceof ProductCollection) {
+      return getDataObjects((ProductCollection) product);
+    } else if (product instanceof ProductFileRepository) {
+      return getDataObjects((ProductFileRepository) product);
+    } else if (product instanceof ProductFileText) {
+      return getDataObjects((ProductFileText) product);
+    } else if (product instanceof ProductMetadataSupplemental) {
       return getDataObjects((ProductMetadataSupplemental) product);
+    } else if (product instanceof ProductNative) {
+      return getDataObjects((ProductNative) product);
+    } else if (product instanceof ProductObservational) {
+      return getDataObjects((ProductObservational) product);
+    } else if (product instanceof ProductSIP) {
+      return getDataObjects((ProductSIP) product);
+    } else if (product instanceof ProductSIPDeepArchive) {
+      return getDataObjects((ProductSIPDeepArchive) product);
+    } else if (product instanceof ProductSPICEKernel) {
+      return getDataObjects((ProductSPICEKernel) product);
+    } else if (product instanceof ProductService) {
+      return getDataObjects((ProductService) product);
+    } else if (product instanceof ProductThumbnail) {
+      return getDataObjects((ProductThumbnail) product);
+    } else if (product instanceof ProductXMLSchema) {
+      return getDataObjects((ProductXMLSchema) product);
     } else {
-      throw new ClassCastException("Only objects from Product_Observational and "
-          + "Product_Metadata_Supplemental labels are supported.");
+      throw new ClassCastException("Unsupported product type.");
     }
   }
 
-
   /**
-   * Extract data objects from Product_Observational label
+   * Extract data objects from Product_AIP label
    *
-   * @param product Product_Observational label
+   * @param product Product_AIP label
    * @return a list of data objects
    * @throws Exception an exception
    */
-  private List<DataObject> getDataObjects(ProductObservational product) throws Exception {
+  private List<DataObject> getDataObjects(ProductAIP product) throws Exception {
     List<DataObject> objects = new ArrayList<>();
 
-    for (FileAreaObservational fileArea : product.getFileAreaObservationals()) {
-      for (ByteStream stream : fileArea.getDataObjects()) {
-        addObject(objects, fileArea.getFile(), stream);
-      }
-    }
-    for (FileAreaObservationalSupplemental supplementalArea : product
-        .getFileAreaObservationalSupplementals()) {
-      for (ByteStream stream : supplementalArea.getDataObjects()) {
-        addObject(objects, supplementalArea.getFile(), stream);
-      }
+    for (InformationPackageComponent comp : product.getInformationPackageComponents()) {
+      addObject(objects, comp.getFileAreaChecksumManifest().getFile(),
+          comp.getFileAreaChecksumManifest().getChecksumManifest(), new DataObjectLocation(1, 1));
+      addObject(objects, comp.getFileAreaTransferManifest().getFile(),
+          comp.getFileAreaTransferManifest().getTransferManifest(), new DataObjectLocation(2, 1));
     }
 
     return objects;
   }
 
+  /**
+   * Extract data objects from Product_Ancillary label
+   *
+   * @param product Product_Ancillary label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductAncillary product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    int fileAreaIndex = 0;
+    int dataObjectIndex = 0;
+    for (FileAreaAncillary fileArea : product.getFileAreaAncillaries()) {
+      fileAreaIndex++;
+      for (ByteStream bs : fileArea.getArraiesAndArray1DsAndArray2Ds()) {
+        addObject(objects, fileArea.getFile(), bs,
+            new DataObjectLocation(fileAreaIndex, ++dataObjectIndex));
+      }
+      dataObjectIndex = 0;
+    }
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_Browse label
+   *
+   * @param product Product_Browse label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductBrowse product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    int fileAreaIndex = 0;
+    int dataObjectIndex = 0;
+    for (FileAreaBrowse fileArea : product.getFileAreaBrowses()) {
+      fileAreaIndex++;
+      for (ByteStream bs : fileArea.getDataObjects()) {
+        addObject(objects, fileArea.getFile(), bs,
+            new DataObjectLocation(fileAreaIndex, ++dataObjectIndex));
+      }
+      dataObjectIndex = 0;
+    }
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_Collection label
+   *
+   * @param product Product_Collection label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductCollection product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    FileAreaInventory fileArea = product.getFileAreaInventory();
+    addObject(objects, fileArea.getFile(), fileArea.getInventory(), new DataObjectLocation(1, 1));
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_File_Repository label
+   *
+   * @param product Product_File_Repository label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductFileRepository product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    FileAreaBinary fileArea = product.getFileAreaBinary();
+
+    int dataObjectIndex = 0;
+    for (EncodedBinary eb : fileArea.getEncodedBinaries()) {
+      addObject(objects, fileArea.getFile(), eb, new DataObjectLocation(1, ++dataObjectIndex));
+    }
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_File_Text label
+   *
+   * @param product Product_File_Text label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductFileText product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    FileAreaText fileArea = product.getFileAreaText();
+
+    addObject(objects, fileArea.getFile(), fileArea.getStreamText(), new DataObjectLocation(1, 1));
+
+    return objects;
+  }
 
   /**
    * Extract data objects from Product_Metadata_Supplemental label
@@ -270,52 +420,227 @@ public class Label {
 
     FileAreaMetadata fileArea = product.getFileAreaMetadata();
 
+    int fileAreaIndex = 0;
+    int dataObjectIndex = 0;
     if (fileArea.getTableCharacter() != null) {
-      addObject(objects, fileArea.getFile(), fileArea.getTableCharacter());
+      addObject(objects, fileArea.getFile(), fileArea.getTableCharacter(),
+          new DataObjectLocation(++fileAreaIndex, ++dataObjectIndex));
     }
 
     if (fileArea.getTableDelimited() != null) {
-      addObject(objects, fileArea.getFile(), fileArea.getTableDelimited());
+      addObject(objects, fileArea.getFile(), fileArea.getTableDelimited(),
+          new DataObjectLocation(++fileAreaIndex, ++dataObjectIndex));
     }
 
     return objects;
   }
 
+  /**
+   * Extract data objects from Product_Native label
+   *
+   * @param product Product_Native label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductNative product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    int fileAreaIndex = 0;
+    int dataObjectIndex = 0;
+    for (FileAreaNative fileArea : product.getFileAreaNatives()) {
+      fileAreaIndex++;
+      for (EncodedNative en : fileArea.getEncodedNatives()) {
+        addObject(objects, fileArea.getFile(), en,
+            new DataObjectLocation(fileAreaIndex, ++dataObjectIndex));
+      }
+      dataObjectIndex = 0;
+    }
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_Observational label
+   *
+   * @param product Product_Observational label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductObservational product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    int fileAreaIndex = 0;
+    int dataObjectIndex = 0;
+    for (FileAreaObservational fileArea : product.getFileAreaObservationals()) {
+      fileAreaIndex++;
+      for (ByteStream stream : fileArea.getDataObjects()) {
+        addObject(objects, fileArea.getFile(), stream,
+            new DataObjectLocation(fileAreaIndex, ++dataObjectIndex));
+      }
+      dataObjectIndex = 0;
+    }
+    for (FileAreaObservationalSupplemental supplementalArea : product
+        .getFileAreaObservationalSupplementals()) {
+      fileAreaIndex++;
+      for (ByteStream stream : supplementalArea.getDataObjects()) {
+        addObject(objects, supplementalArea.getFile(), stream,
+            new DataObjectLocation(fileAreaIndex, dataObjectIndex));
+      }
+      dataObjectIndex = 0;
+    }
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_Service label
+   *
+   * @param product Product_Service label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductService product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    int fileAreaIndex = 0;
+    int dataObjectIndex = 0;
+    for (FileAreaServiceDescription fileArea : product.getFileAreaServiceDescriptions()) {
+      fileAreaIndex++;
+      for (ServiceDescription sd : fileArea.getServiceDescriptions()) {
+        addObject(objects, fileArea.getFile(), sd,
+            new DataObjectLocation(fileAreaIndex, ++dataObjectIndex));
+      }
+      dataObjectIndex = 0;
+    }
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_SIP label
+   *
+   * @param product Product_SIP label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductSIP product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    for (InformationPackageComponent comp : product.getInformationPackageComponents()) {
+      addObject(objects, comp.getFileAreaChecksumManifest().getFile(),
+          comp.getFileAreaChecksumManifest().getChecksumManifest(), new DataObjectLocation(1, 1));
+      addObject(objects, comp.getFileAreaTransferManifest().getFile(),
+          comp.getFileAreaTransferManifest().getTransferManifest(), new DataObjectLocation(2, 1));
+    }
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_SIP_Deep_Archive label
+   *
+   * @param product Product_SIP_Deep_Archive label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductSIPDeepArchive product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    FileAreaSIPDeepArchive fileArea =
+        product.getInformationPackageComponentDeepArchive().getFileAreaSIPDeepArchive();
+
+    addObject(objects, fileArea.getFile(), fileArea.getManifestSIPDeepArchive(),
+        new DataObjectLocation(1, 1));
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_SPICE_Kernel label
+   *
+   * @param product Product_SPICE_Kernel label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductSPICEKernel product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    FileAreaSPICEKernel fileArea = product.getFileAreaSPICEKernel();
+
+    addObject(objects, fileArea.getFile(), fileArea.getSPICEKernel(), new DataObjectLocation(1, 1));
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_Thumbnail label
+   *
+   * @param product Product_Thumbnail label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductThumbnail product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    FileAreaEncodedImage fileArea = product.getFileAreaEncodedImage();
+    addObject(objects, fileArea.getFile(), fileArea.getEncodedImage(),
+        new DataObjectLocation(1, 1));
+
+    return objects;
+  }
+
+  /**
+   * Extract data objects from Product_XML_Schema label
+   *
+   * @param product Product_XML_Schema label
+   * @return a list of data objects
+   * @throws Exception an exception
+   */
+  private List<DataObject> getDataObjects(ProductXMLSchema product) throws Exception {
+    List<DataObject> objects = new ArrayList<>();
+
+    int dataObjectIndex = 0;
+    for (FileAreaXMLSchema fileArea : product.getFileAreaXMLSchemas()) {
+      addObject(objects, fileArea.getFile(), fileArea.getXMLSchema(),
+          new DataObjectLocation(1, ++dataObjectIndex));
+    }
+
+    return objects;
+  }
 
   private void addObject(Collection<DataObject> objects, gov.nasa.arc.pds.xml.generated.File file,
-      ByteStream stream) throws Exception {
+      ByteStream stream, DataObjectLocation location) throws Exception {
     if (stream instanceof TableBinary) {
-      objects.add(makeTable(file, (TableBinary) stream));
+      objects.add(makeTable(file, (TableBinary) stream, location));
     } else if (stream instanceof TableCharacter) {
-      TableCharacter table = (TableCharacter) stream;
-      objects.add(makeTable(file, table));
+      objects.add(makeTable(file, (TableCharacter) stream, location));
     } else if (stream instanceof TableDelimited) {
-      objects.add(makeTable(file, (TableDelimited) stream));
+      objects.add(makeTable(file, (TableDelimited) stream, location));
     } else if (stream instanceof Array) {
-      objects.add(makeArray(file, (Array) stream));
+      objects.add(makeArray(file, (Array) stream, location));
     } else {
-      objects.add(makeGenericObject(file, stream));
+      objects.add(makeGenericObject(file, stream, location));
     }
   }
 
-  private DataObject makeTable(gov.nasa.arc.pds.xml.generated.File file, TableBinary table)
-      throws Exception {
+  private DataObject makeTable(gov.nasa.arc.pds.xml.generated.File file, TableBinary table,
+      DataObjectLocation location) throws Exception {
     BigInteger size =
         table.getRecords().multiply(table.getRecordBinary().getRecordLength().getValue());
     return new TableObject(parentDir, file, table, table.getOffset().getValue().longValueExact(),
-        size.longValueExact());
+        size.longValueExact(), location);
   }
 
-  private DataObject makeTable(gov.nasa.arc.pds.xml.generated.File file, TableCharacter table)
-      throws Exception {
+  private DataObject makeTable(gov.nasa.arc.pds.xml.generated.File file, TableCharacter table,
+      DataObjectLocation location) throws Exception {
     BigInteger size =
         table.getRecords().multiply(table.getRecordCharacter().getRecordLength().getValue());
     return new TableObject(parentDir, file, table, table.getOffset().getValue().longValueExact(),
-        size.longValueExact());
+        size.longValueExact(), location);
   }
 
-  private DataObject makeTable(gov.nasa.arc.pds.xml.generated.File file, TableDelimited table)
-      throws Exception {
+  private DataObject makeTable(gov.nasa.arc.pds.xml.generated.File file, TableDelimited table,
+      DataObjectLocation location) throws Exception {
     // The range for a delimited table must be the rest of the file past the offset position.
     long offset = 0;
     if (table.getOffset() != null) {
@@ -325,16 +650,17 @@ public class Label {
     if (file.getFileSize() != null) {
       size = file.getFileSize().getValue().longValue() - offset;
     }
-    return new TableObject(parentDir, file, table, offset, size);
+    return new TableObject(parentDir, file, table, offset, size, location);
   }
 
-  private DataObject makeArray(gov.nasa.arc.pds.xml.generated.File file, Array array)
-      throws FileNotFoundException, IOException {
-    return new ArrayObject(parentDir, file, array, array.getOffset().getValue().longValueExact());
+  private DataObject makeArray(gov.nasa.arc.pds.xml.generated.File file, Array array,
+      DataObjectLocation location) throws FileNotFoundException, IOException, URISyntaxException {
+    return new ArrayObject(parentDir, file, array, array.getOffset().getValue().longValueExact(),
+        location);
   }
 
-  private DataObject makeGenericObject(gov.nasa.arc.pds.xml.generated.File file, ByteStream stream)
-      throws IOException {
+  private DataObject makeGenericObject(gov.nasa.arc.pds.xml.generated.File file, ByteStream stream,
+      DataObjectLocation location) throws IOException, URISyntaxException {
     long size = -1;
     long offset = -1;
     if (stream instanceof EncodedByteStream) {
@@ -343,9 +669,11 @@ public class Label {
       offset = ebs.getOffset().getValue().longValueExact();
     } else if (stream instanceof ParsableByteStream) {
       ParsableByteStream pbs = (ParsableByteStream) stream;
-      size = pbs.getObjectLength().getValue().longValueExact();
+      if (pbs.getObjectLength() != null) {
+        size = pbs.getObjectLength().getValue().longValueExact();
+      }
       offset = pbs.getOffset().getValue().longValueExact();
     }
-    return new GenericObject(parentDir, file, offset, size);
+    return new GenericObject(parentDir, file, offset, size, location);
   }
 }

--- a/src/main/java/gov/nasa/pds/label/object/DataObjectLocation.java
+++ b/src/main/java/gov/nasa/pds/label/object/DataObjectLocation.java
@@ -1,0 +1,77 @@
+package gov.nasa.pds.label.object;
+
+import java.net.URL;
+
+public class DataObjectLocation {
+  /** The label associated with the data. */
+  private URL label;
+
+  /** The data file associated with the record. */
+  private URL dataFile;
+
+  /** The index of the fileArea associated with the data object. */
+  private int fileArea;
+
+  /** The index of the data object within the file area. */
+  private int dataObject;
+
+  /**
+   * Constructor.
+   *
+   * @param label The label.
+   * @param dataFile The data file.
+   * @param fileArea The File_Area_* index.
+   * @param dataObject The index of the data object within the file area
+   */
+  public DataObjectLocation(URL label, URL dataFile, int fileArea, int dataObject) {
+    this.label = label;
+    this.dataFile = dataFile;
+    this.fileArea = fileArea;
+    this.dataObject = dataObject;
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param fileArea The File_Area_* index.
+   * @param dataObject The index of the data object within the file area
+   */
+  public DataObjectLocation(int fileArea, int dataObject) {
+    this.label = null;
+    this.dataFile = null;
+    this.fileArea = fileArea;
+    this.dataObject = dataObject;
+  }
+
+  public URL getLabel() {
+    return label;
+  }
+
+  public void setLabel(URL label) {
+    this.label = label;
+  }
+
+  public URL getDataFile() {
+    return dataFile;
+  }
+
+  public void setDataFile(URL dataFile) {
+    this.dataFile = dataFile;
+  }
+
+  public int getFileArea() {
+    return fileArea;
+  }
+
+  public void setFileArea(int fileArea) {
+    this.fileArea = fileArea;
+  }
+
+  public int getDataObject() {
+    return dataObject;
+  }
+
+  public void setDataObject(int dataObject) {
+    this.dataObject = dataObject;
+  }
+}

--- a/src/main/java/gov/nasa/pds/label/object/GenericObject.java
+++ b/src/main/java/gov/nasa/pds/label/object/GenericObject.java
@@ -32,6 +32,7 @@ package gov.nasa.pds.label.object;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 /**
@@ -48,10 +49,11 @@ public class GenericObject extends DataObject {
    * @param offset the offset within the file of the start of the data object
    * @param size the size of the data object, in bytes
    * @throws IOException if an error occurred initializng the object
+   * @throws URISyntaxException
    */
   public GenericObject(File parentDir, gov.nasa.arc.pds.xml.generated.File fileObject, long offset,
-      long size) throws IOException {
-    this(parentDir.toURI().toURL(), fileObject, offset, size);
+      long size, DataObjectLocation location) throws IOException, URISyntaxException {
+    this(parentDir.toURI().toURL(), fileObject, offset, size, location);
   }
 
   /**
@@ -62,10 +64,29 @@ public class GenericObject extends DataObject {
    * @param offset the offset within the file of the start of the data object
    * @param size the size of the data object, in bytes
    * @throws IOException if an error occurred initializng the object
+   * @throws URISyntaxException
    */
   public GenericObject(URL parentDir, gov.nasa.arc.pds.xml.generated.File fileObject, long offset,
-      long size) throws IOException {
-    super(parentDir, fileObject, offset, size);
+      long size, DataObjectLocation location) throws IOException, URISyntaxException {
+    super(parentDir, fileObject, offset, size, location);
+  }
+
+  /**
+   * Deprecated initializer. Missing DataObjectLocation
+   */
+  @Deprecated
+  public GenericObject(File parentDir, gov.nasa.arc.pds.xml.generated.File fileObject, long offset,
+      long size) throws IOException, URISyntaxException {
+    this(parentDir.toURI().toURL(), fileObject, offset, size, null);
+  }
+
+  /**
+   * Deprecated initializer. Missing DataObjectLocation
+   */
+  @Deprecated
+  public GenericObject(URL parentDir, gov.nasa.arc.pds.xml.generated.File fileObject, long offset,
+      long size) throws IOException, URISyntaxException {
+    this(parentDir, fileObject, offset, size, null);
   }
 
 }

--- a/src/main/java/gov/nasa/pds/label/object/RecordLocation.java
+++ b/src/main/java/gov/nasa/pds/label/object/RecordLocation.java
@@ -46,8 +46,8 @@ public final class RecordLocation {
   /** The data file associated with the record. */
   private URL dataFile;
 
-  /** The index of the table associated with the record. */
-  private int table;
+  /** The location of table associated with the record. */
+  private DataObjectLocation dataObjectLocation;
 
   /** The index of the record. */
   private long record;
@@ -60,8 +60,9 @@ public final class RecordLocation {
    * @param table The table index.
    * @param record The record index as integer.
    */
-  public RecordLocation(URL label, URL dataFile, int table, int record) {
-    this(label, dataFile, table, (long) record);
+  public RecordLocation(URL label, URL dataFile, DataObjectLocation dataObjectLocation,
+      int record) {
+    this(label, dataFile, dataObjectLocation, (long) record);
   }
 
   /**
@@ -72,10 +73,11 @@ public final class RecordLocation {
    * @param table The table index.
    * @param record The record index as a long.
    */
-  public RecordLocation(URL label, URL dataFile, int table, long record) {
+  public RecordLocation(URL label, URL dataFile, DataObjectLocation dataObjectLocation,
+      long record) {
     this.label = label;
     this.dataFile = dataFile;
-    this.table = table;
+    this.dataObjectLocation = dataObjectLocation;
     this.record = record;
   }
 
@@ -97,10 +99,10 @@ public final class RecordLocation {
 
   /**
    *
-   * @return the table index.
+   * @return the data object location.
    */
-  public int getTable() {
-    return this.table;
+  public DataObjectLocation getDataObjectLocation() {
+    return this.dataObjectLocation;
   }
 
   /**

--- a/src/main/java/gov/nasa/pds/objectAccess/ByteWiseFileAccessor.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/ByteWiseFileAccessor.java
@@ -161,6 +161,7 @@ public class ByteWiseFileAccessor implements Closeable {
       long fileSizeMinusOffset = Math.max(0, this.totalFileContentSize - offset);
 
       actualBytesToRead = expectedBytesToRead;
+
       if (expectedBytesToRead <= 0 || expectedBytesToRead > fileSizeMinusOffset) {
         actualBytesToRead = fileSizeMinusOffset;
       }
@@ -187,14 +188,20 @@ public class ByteWiseFileAccessor implements Closeable {
       this.curPosition = 0;
 
       // if for whatever reason we don't read in sufficient bytes
-      if (totalBytesRead < expectedBytesToRead) {
-        throw new InvalidTableException("Expected to read in " + expectedBytesToRead
-            + " bytes but only " + totalBytesRead + " bytes were read for " + url.toString());
+      if (this.totalBytesRead < expectedBytesToRead) {
+        if (expectedBytesToRead > fileSizeMinusOffset) {
+          throw new InvalidTableException(
+              "Cannot read object. Remaining file size: " + fileSizeMinusOffset
+                  + ", Expected bytes remaining for object: " + expectedBytesToRead);
+        } else {
+          throw new InvalidTableException("Expected to read in " + expectedBytesToRead
+              + " bytes but only " + totalBytesRead + " bytes were read for " + url.toString());
+        }
       }
 
       LOGGER.debug("ByteWiseFileAccessor: url {}", url);
       LOGGER.debug("ByteWiseFileAccessor: fileSize,sizeToRead {},{}", url, expectedBytesToRead);
-      LOGGER.debug("ByteWiseFileAccessor: totalBytesRead {}", totalBytesRead);
+      LOGGER.debug("ByteWiseFileAccessor: totalBytesRead {}", this.totalBytesRead);
       LOGGER.debug("ByteWiseFileAccessor: mappings.size() {}", mappings.size());
     } catch (java.nio.channels.NonWritableChannelException ex) {
       // don't do anything
@@ -329,7 +336,7 @@ public class ByteWiseFileAccessor implements Closeable {
     LOGGER.debug("readRecordBytes: mapN,offN {},{}", mapN, offN);
     LOGGER.debug("readRecordBytes: this.recordLength {}", this.recordLength);
     LOGGER.debug("readRecordBytes: bytesToReturn.length {}", bytesToReturn.length);
-    LOGGER.debug("readRecordBytes: bytesToReturn {}", new String(bytesToReturn));
+    LOGGER.debug("readRecordBytes: bytesToReturn '{}'", new String(bytesToReturn));
 
     return bytesToReturn;
   }

--- a/src/main/java/gov/nasa/pds/objectAccess/ExporterFactory.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/ExporterFactory.java
@@ -33,6 +33,7 @@ package gov.nasa.pds.objectAccess;
 import java.io.File;
 import java.net.URL;
 import gov.nasa.arc.pds.xml.generated.FileAreaObservational;
+import gov.nasa.pds.label.object.DataObjectLocation;
 
 /**
  * Factory pattern class to create specific object exporters.
@@ -222,5 +223,30 @@ public class ExporterFactory {
    */
   public static TableReader getTableReader(Object tableObject, URL dataFile) throws Exception {
     return new TableReader(tableObject, dataFile, true);
+  }
+
+  /**
+   * Gets a table reader object for a given table and data file.
+   *
+   * @param tableObject the table object, binary, character, or delimited
+   * @param dataFile the data file containing the table
+   * @return a table reader for the table
+   * @throws Exception if there is an error reading the file
+   */
+  public static TableReader getRawTableReader(Object tableObject, File dataFile) throws Exception {
+    return getTableReader(tableObject, dataFile.toURI().toURL());
+  }
+
+  /**
+   * Gets a table reader object for a given table and data file.
+   *
+   * @param tableObject the table object, binary, character, or delimited
+   * @param dataFile the data file containing the table
+   * @return a table reader for the table
+   * @throws Exception if there is an error reading the file
+   */
+  public static RawTableReader getRawTableReader(Object tableObject, URL dataFile,
+      DataObjectLocation location) throws Exception {
+    return new RawTableReader(tableObject, dataFile, location, true);
   }
 }

--- a/src/main/java/gov/nasa/pds/objectAccess/ObjectProvider.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/ObjectProvider.java
@@ -46,6 +46,7 @@ import gov.nasa.arc.pds.xml.generated.FileAreaBrowse;
 import gov.nasa.arc.pds.xml.generated.FileAreaObservational;
 import gov.nasa.arc.pds.xml.generated.FileAreaObservationalSupplemental;
 import gov.nasa.arc.pds.xml.generated.GroupFieldDelimited;
+import gov.nasa.arc.pds.xml.generated.Product;
 import gov.nasa.arc.pds.xml.generated.ProductObservational;
 import gov.nasa.arc.pds.xml.generated.TableBinary;
 import gov.nasa.arc.pds.xml.generated.TableCharacter;
@@ -71,6 +72,8 @@ public interface ObjectProvider {
    * @return the root file path of the object archive(s) for this ObjectProvider
    */
   URL getRoot();
+
+  public List<Object> getDataObjects(Product product) throws ParseException;
 
   /**
    * Gets a list of Array objects from a file area.
@@ -296,4 +299,7 @@ public interface ObjectProvider {
   void setObservationalProduct(String relativeXmlFilePath, ProductObservational product,
       XMLLabelContext context) throws Exception;
 
+  long getOffset(Object obj) throws Exception;
+
+  long getObjectLength(Object obj) throws Exception;
 }

--- a/src/main/java/gov/nasa/pds/objectAccess/RawTableReader.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/RawTableReader.java
@@ -1,0 +1,236 @@
+package gov.nasa.pds.objectAccess;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
+import java.net.URL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.opencsv.exceptions.CsvValidationException;
+import gov.nasa.pds.label.object.DataObjectLocation;
+import gov.nasa.pds.label.object.RecordLocation;
+import gov.nasa.pds.label.object.TableRecord;
+
+/**
+ * Table reader that provides the capability to read a table line by line rather than record by
+ * record, which is more strict as it relies on the label metadata.
+ *
+ * @author mcayanan
+ *
+ */
+public class RawTableReader extends TableReader {
+  private static final Logger LOG = LoggerFactory.getLogger(RawTableReader.class);
+
+  /** The data file. */
+  private URL dataFile;
+
+  /** The label associated with the table. */
+  private URL label;
+
+  private int nextCh = SOL;
+
+  private static final int SOL = -10;
+
+  /**
+   * Constructor.
+   * 
+   * @param table The table object.
+   * @param dataFile The data file.
+   * @param label The label.
+   * @param location The location of the table within the metadata definition
+   * @param readEntireFile Set to 'true' to read in entire data file.
+   * @throws Exception If table offset is null.
+   */
+  public RawTableReader(Object table, URL dataFile, URL label, DataObjectLocation location,
+      boolean readEntireFile) throws Exception {
+    super(table, dataFile, false, readEntireFile);
+    this.dataFile = dataFile;
+    this.label = label;
+  }
+
+  /**
+   * Constructor.
+   * 
+   * @param table The table object.
+   * @param dataFile The data file.
+   * @param label The label.
+   * @param location The location of the table within the metadata definition
+   * @param readEntireFile Set to 'true' to read in entire data file.
+   * @param keepQuotationsFlag Flag to optionally preserve the leading and trailing quotes.
+   * @throws Exception If table offset is null.
+   */
+  public RawTableReader(Object table, URL dataFile, URL label, DataObjectLocation location,
+      boolean readEntireFile, boolean keepQuotationsFlag) throws Exception {
+    super(table, dataFile, location, false, readEntireFile, keepQuotationsFlag);
+    this.dataFile = dataFile;
+    this.label = label;
+  }
+
+  /**
+   * Constructor.
+   * 
+   * @param table The table object.
+   * @param dataFile The data file.
+   * @param label The label.
+   * @param location The location of the table within the metadata definition
+   * @param readEntireFile Set to 'true' to read in entire data file.
+   * @param keepQuotationsFlag Flag to optionally preserve the leading and trailing quotes.
+   * @param fileChannel file channel stream used for ByteWideFileAccessor
+   * @param inputStream input stream of the file used for CSVReader
+   * @throws Exception If table offset is null.
+   */
+  public RawTableReader(Object table, URL dataFile, URL label, DataObjectLocation location,
+      boolean readEntireFile, boolean keepQuotationsFlag, RandomAccessFile raf,
+      InputStream inputStream) throws Exception {
+    super(table, dataFile, location, false, readEntireFile, keepQuotationsFlag, raf, inputStream);
+    this.dataFile = dataFile;
+    this.label = label;
+  }
+
+  public RawTableReader(Object table, URL dataFile, DataObjectLocation location, boolean checkSize)
+      throws InvalidTableException, Exception {
+    this(table, dataFile, null, location, checkSize, true);
+  }
+
+  /**
+   * Previews the next line in the data file.
+   * 
+   * @return the next line, or null if no further lines.
+   * 
+   * @throws IOException
+   */
+  public String readNextLine() throws IOException {
+    String line = null;
+    int ch = (char) -10;
+    StringBuilder lineBuffer = new StringBuilder();
+    if (nextCh == -1) {
+      line = null;
+      LOG.debug("readNextLine:nextCh == -1");
+    } else {
+      boolean newLine = false;
+      boolean eof = false;
+      while (!newLine && !eof) {
+        if (nextCh != -10) {
+          lineBuffer.append((char) nextCh);
+        }
+        nextCh = -10;
+        if (accessor.hasRemaining()) {
+          ch = accessor.readByte();
+          switch (ch) {
+            case '\r':
+              // check for double newline char
+              if (accessor.hasRemaining()) {
+                nextCh = accessor.readByte();
+                if (nextCh == '\n') {
+                  // double line found
+                  lineBuffer.append("\r\n");
+                  newLine = true;
+                  nextCh = -10;
+                } else {
+                  lineBuffer.append("\r");
+                  newLine = true;
+                }
+              } else {
+                eof = true;
+                nextCh = -1;
+              }
+              break;
+
+            case '\n':
+              lineBuffer.append("\n");
+              newLine = true;
+              break;
+
+            case -1:
+              eof = true;
+              nextCh = -1;
+              break;
+
+            default:
+              if (ch != -1) {
+                lineBuffer.append((char) ch);
+              }
+          }
+        } else {
+          eof = true;
+          nextCh = -1;
+        }
+      }
+      if (lineBuffer.length() > 0) {
+        line = lineBuffer.toString();
+        setCurrentRow(getCurrentRow() + 1);
+      }
+    }
+
+    if (line != null) {
+      LOG.debug("readNextLine:line:{},[{}]", line.length(), line);
+    } else {
+      LOG.debug("readNextLine:line is null");
+    }
+
+    return line;
+  }
+
+  /**
+   * Converts the given line to a record.
+   * 
+   * @param line The line to convert.
+   * @param row The row number to set.
+   * 
+   * @return A record.
+   */
+  public FixedTableRecord toRecord(String line, long row) {
+    FixedTableRecord record = null;
+    record = new FixedTableRecord(line.getBytes(), getFieldMap(), getFields());
+    record.setLocation(new RecordLocation(label, dataFile, dataObjectLocation, row));
+    return record;
+  }
+
+  /**
+   * Reads the next record in the table.
+   * 
+   * @return a table record, with the location set.
+   */
+  @Override
+  public TableRecord readNext() throws IOException {
+    try {
+      TableRecord record = super.readNext();
+      if (record != null) {
+        LOG.debug("Setting record location");
+        record.setLocation(getLocation());
+      }
+      return record;
+    } catch (CsvValidationException ex) {
+      LOG.error("Function readNext() has failed");
+      throw new IOException(ex.getMessage());
+    }
+  }
+
+  /**
+   * Gets a record in the table.
+   * 
+   * @param The index of the record.
+   * 
+   * @return a table record, with the location set.
+   */
+  @Override
+  public TableRecord getRecord(long index, boolean keepQuotationsFlag)
+      throws IllegalArgumentException, IOException {
+    try {
+      TableRecord record = super.getRecord(index, keepQuotationsFlag);
+      record.setLocation(getLocation());
+      return record;
+    } catch (CsvValidationException ex) {
+      LOG.error("Function getRecord has failed");
+      throw new IOException(ex.getMessage());
+    }
+  }
+
+  /**
+   * 
+   * @return the location of the record.
+   */
+  private RecordLocation getLocation() {
+    return new RecordLocation(label, dataFile, dataObjectLocation, getCurrentRow());
+  }
+}

--- a/src/main/java/gov/nasa/pds/objectAccess/array/ArrayAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/array/ArrayAdapter.java
@@ -49,13 +49,28 @@ public class ArrayAdapter {
    * data type name.
    * 
    * @param dimensions the array dimensions
+   * @param elementType the element type
+   */
+  public ArrayAdapter(int[] dimensions, ElementType elementType) {
+    this(dimensions, null, elementType);
+  }
+
+  /**
+   * Creates a new array adapter with given dimensions, a channel with the array data, and element
+   * data type name.
+   * 
+   * @param dimensions the array dimensions
    * @param channel the channel object containing the array data
-   * @param elementType the elmeent type
+   * @param elementType the element type
    */
   public ArrayAdapter(int[] dimensions, SeekableByteChannel channel, ElementType elementType) {
     this.dimensions = dimensions;
     this.elementType = elementType;
-    this.buf = new MappedBuffer(channel, elementType.getSize());
+
+    if (channel != null) {
+      this.open(channel);
+    }
+
   }
 
   /**
@@ -188,6 +203,7 @@ public class ArrayAdapter {
       index = index * dimensions[i] + position[i];
     }
     index = index * elementType.getSize();
+
     return buf.getBuffer(index);
   }
 
@@ -196,6 +212,18 @@ public class ArrayAdapter {
       throw new IllegalArgumentException("Array position as wrong number of dimensions: "
           + position.length + "!=" + dimensions.length);
     }
+  }
+
+  public MappedBuffer getBuf() {
+    return buf;
+  }
+
+  public void open(SeekableByteChannel channel) {
+    this.buf = new MappedBuffer(channel, this.elementType.getSize());
+  }
+
+  public void close() throws IOException {
+    this.buf.close();
   }
 
   /**
@@ -277,6 +305,17 @@ public class ArrayAdapter {
       ((Buffer) buf).flip();
       startPosition = index;
       return buf;
+    }
+
+    /**
+     * Get the buffer.
+     * 
+     * @param index The position of where to get the data.
+     * @return The ByteBuffer.
+     * @throws IOException an exception
+     */
+    public void close() throws IOException {
+      channel.close();
     }
   }
 }

--- a/src/main/java/gov/nasa/pds/objectAccess/table/DelimiterType.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/DelimiterType.java
@@ -54,7 +54,10 @@ public enum DelimiterType {
   VERTICAL_BAR("vertical bar", '|'),
 
   /** Carriage return and line feed (CRLF) record delimiter. */
-  CARRIAGE_RETURN_LINE_FEED("carriage-return line-feed", "\r\n");
+  CARRIAGE_RETURN_LINE_FEED("carriage-return line-feed", "\r\n"),
+
+  /** Line feed (LF) record delimiter. */
+  LINE_FEED("line-feed", "\n");
 
   private static Map<String, DelimiterType> xmlTypeMap = new HashMap<>();
   static {

--- a/src/main/java/gov/nasa/pds/objectAccess/table/TableAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/TableAdapter.java
@@ -30,6 +30,7 @@
 
 package gov.nasa.pds.objectAccess.table;
 
+import java.util.List;
 import gov.nasa.pds.label.object.FieldDescription;
 
 /**
@@ -48,6 +49,10 @@ public interface TableAdapter {
   /**
    * Gets the number of fields in each record.
    * 
+   * TODO This should really be a long value, but this would require a ton of changes in the code so
+   * we will attack this problem when we get there. Data with num fields larger than max int should
+   * not happen
+   * 
    * @return the number of fields
    */
   int getFieldCount();
@@ -63,11 +68,19 @@ public interface TableAdapter {
 
   /**
    * Gets the definitions of fields from the table. The fields will be a simple field or a bit
-   * field. All grouped fiels will have been expanded to their instances.
+   * field. All grouped fields will have been expanded to their instances.
    * 
    * @return an array of field descriptions
    */
   FieldDescription[] getFields();
+
+  /**
+   * Gets the definitions of fields from the table. The fields will be a simple field or a bit
+   * field. All grouped fields will have been expanded to their instances.
+   * 
+   * @return an array of field descriptions
+   */
+  List<FieldDescription> getFieldsList();
 
   /**
    * Gets the offset into the data file where the table starts.
@@ -77,11 +90,38 @@ public interface TableAdapter {
   long getOffset();
 
   /**
-   * Gets the length of each record. For delimited tables the record length is not defined, so zero
-   * is returned.
+   * Gets the length of each record. For delimited tables the record length is not defined, so -1 is
+   * returned.
+   * 
+   * TODO This should really be a long value, but this would require a ton of changes in the code we
+   * will attack this problem when we get there. Data with record length larger than max int should
+   * not happen
    * 
    * @return the record length, or zero for a delimited table
    */
   int getRecordLength();
+
+  /**
+   * Gets the maximum length of each record. Optional only for delimited tables. Will return -1 if
+   * not available.
+   * 
+   * @return the maximum record lengths
+   */
+  int getMaximumRecordLength();
+
+  /**
+   * Gets the record delimiter. For binary tables the record delimiter is not defined, so null is
+   * returned.
+   * 
+   * @return the record delimiter, or null for binary table
+   */
+  String getRecordDelimiter();
+
+  /**
+   * Gets the field delimiter. For non-delimited tables, will return 0.
+   * 
+   * @return the field delimiter, or 0 for non-delimited table
+   */
+  char getFieldDelimiter();
 
 }

--- a/src/main/java/gov/nasa/pds/objectAccess/table/TableDelimitedAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/TableDelimitedAdapter.java
@@ -37,22 +37,28 @@ import gov.nasa.arc.pds.xml.generated.GroupFieldDelimited;
 import gov.nasa.arc.pds.xml.generated.TableDelimited;
 import gov.nasa.pds.label.object.FieldDescription;
 import gov.nasa.pds.label.object.FieldType;
+import gov.nasa.pds.objectAccess.InvalidTableException;
+import gov.nasa.pds.objectAccess.utility.Utility;
 
 public class TableDelimitedAdapter implements TableAdapter {
 
-  TableDelimited table;
-  List<FieldDescription> fields;
+  private TableDelimited table;
+  private List<FieldDescription> fields;
 
   /**
    * Creates a new instance for a particular table.
    * 
    * @param table the table
+   * @throws InvalidTableException
    */
-  public TableDelimitedAdapter(TableDelimited table) {
+  public TableDelimitedAdapter(TableDelimited table) throws InvalidTableException {
     this.table = table;
 
-    fields = new ArrayList<>();
+    this.fields = new ArrayList<FieldDescription>();
     expandFields(table.getRecordDelimited().getFieldDelimitedsAndGroupFieldDelimiteds());
+
+    Utility.validateCounts(this.getFieldCount(), this.fields.size(),
+        "Invalid fields count definition.");
   }
 
   private void expandFields(List<Object> fields) {
@@ -126,10 +132,29 @@ public class TableDelimitedAdapter implements TableAdapter {
 
   @Override
   public int getRecordLength() {
-    return 0;
+    return -1;
   }
 
+  @Override
+  public String getRecordDelimiter() {
+    return this.table.getRecordDelimiter();
+  }
+
+  @Override
   public char getFieldDelimiter() {
     return DelimiterType.getDelimiterType(table.getFieldDelimiter()).getFieldDelimiter();
+  }
+
+  @Override
+  public List<FieldDescription> getFieldsList() {
+    return this.fields;
+  }
+
+  @Override
+  public int getMaximumRecordLength() {
+    if (this.table.getRecordDelimited().getMaximumRecordLength() != null) {
+      return this.table.getRecordDelimited().getMaximumRecordLength().getValue().intValueExact();
+    }
+    return -1;
   }
 }

--- a/src/main/java/gov/nasa/pds/objectAccess/utility/Utility.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/utility/Utility.java
@@ -41,6 +41,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import org.xml.sax.InputSource;
+import gov.nasa.pds.objectAccess.InvalidTableException;
 
 /**
  * Utility class.
@@ -143,5 +144,14 @@ public class Utility {
     }
     inputSource.setSystemId(uri.toString());
     return inputSource;
+  }
+
+  public static void validateCounts(int expected, int actual, String errorMessage)
+      throws InvalidTableException {
+    // Check fields count
+    if (expected != actual) {
+      throw new InvalidTableException(
+          errorMessage + " Expected: " + expected + ", Actual: " + actual);
+    }
   }
 }

--- a/src/test/java/gov/nasa/pds/label/object/ArrayObjectTest.java
+++ b/src/test/java/gov/nasa/pds/label/object/ArrayObjectTest.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
+import java.net.URISyntaxException;
 import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
 import java.nio.MappedByteBuffer;
@@ -55,13 +56,16 @@ import gov.nasa.arc.pds.xml.generated.Offset;
 public class ArrayObjectTest {
 
   @Test
-  public void test2DDouble() throws IOException, InstantiationException, IllegalAccessException {
+  public void test2DDouble()
+      throws IOException, InstantiationException, IllegalAccessException, URISyntaxException {
     int[] expectedDimensions = {2, 3};
     File tempFile = createDoubleArray(expectedDimensions);
     gov.nasa.arc.pds.xml.generated.File fileObj = createFileObject(tempFile);
     Array arrayObj = createArrayObject(Array2D.class, expectedDimensions, "IEEE754MSBDouble");
 
     ArrayObject array = new ArrayObject(tempFile.getParentFile(), fileObj, arrayObj, 0);
+    array.open();
+
     checkDimensions(array, expectedDimensions);
 
     assertEquals(array.getElementSize(), Double.SIZE / Byte.SIZE);
@@ -92,16 +96,21 @@ public class ArrayObjectTest {
         ++expected;
       }
     }
+
+    array.close();
   }
 
   @Test
-  public void test3DDouble() throws IOException, InstantiationException, IllegalAccessException {
+  public void test3DDouble()
+      throws IOException, InstantiationException, IllegalAccessException, URISyntaxException {
     int[] expectedDimensions = {2, 3, 4};
     File tempFile = createDoubleArray(expectedDimensions);
     gov.nasa.arc.pds.xml.generated.File fileObj = createFileObject(tempFile);
     Array arrayObj = createArrayObject(Array2D.class, expectedDimensions, "IEEE754MSBDouble");
 
     ArrayObject array = new ArrayObject(tempFile.getParentFile(), fileObj, arrayObj, 0);
+    array.open();
+
     checkDimensions(array, expectedDimensions);
 
     assertEquals(array.getElementSize(), Double.SIZE / Byte.SIZE);
@@ -143,12 +152,14 @@ public class ArrayObjectTest {
         }
       }
     }
+
+    array.close();
   }
 
   @Test(dataProvider = "BadIndicesTests",
       expectedExceptions = {ArrayIndexOutOfBoundsException.class, IllegalArgumentException.class})
   public void testBadIndices(int[] position)
-      throws IOException, InstantiationException, IllegalAccessException {
+      throws IOException, InstantiationException, IllegalAccessException, URISyntaxException {
     int[] expectedDimensions = {2, 3};
     File tempFile = createDoubleArray(expectedDimensions);
     gov.nasa.arc.pds.xml.generated.File fileObj = createFileObject(tempFile);

--- a/src/test/java/gov/nasa/pds/label/object/GenericObjectTest.java
+++ b/src/test/java/gov/nasa/pds/label/object/GenericObjectTest.java
@@ -37,6 +37,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.net.URISyntaxException;
 import java.nio.Buffer;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -49,7 +50,7 @@ import gov.nasa.arc.pds.xml.generated.UnitsOfStorage;
 public class GenericObjectTest {
 
   @Test
-  public void testGetters() throws IOException {
+  public void testGetters() throws IOException, URISyntaxException {
     File f = createTempFile("hello");
     gov.nasa.arc.pds.xml.generated.File fileObject = getFileObject(f);
     GenericObject obj = new GenericObject(f.getParentFile(), fileObject, 1, 2);
@@ -61,7 +62,7 @@ public class GenericObjectTest {
   }
 
   @Test
-  public void testReadStreamEntireFile() throws IOException {
+  public void testReadStreamEntireFile() throws IOException, URISyntaxException {
     File f = createTempFile("hello");
     gov.nasa.arc.pds.xml.generated.File fileObject = getFileObject(f);
     GenericObject obj = new GenericObject(f.getParentFile(), fileObject, 0, f.length());
@@ -71,7 +72,7 @@ public class GenericObjectTest {
   }
 
   @Test
-  public void testReadBufferEntireFile() throws IOException {
+  public void testReadBufferEntireFile() throws IOException, URISyntaxException {
     File f = createTempFile("hello");
     gov.nasa.arc.pds.xml.generated.File fileObject = getFileObject(f);
     GenericObject obj = new GenericObject(f.getParentFile(), fileObject, 0, f.length());
@@ -81,7 +82,7 @@ public class GenericObjectTest {
   }
 
   @Test
-  public void testReadStreamPartial() throws IOException {
+  public void testReadStreamPartial() throws IOException, URISyntaxException {
     File f = createTempFile("hello");
     gov.nasa.arc.pds.xml.generated.File fileObject = getFileObject(f);
     GenericObject obj = new GenericObject(f.getParentFile(), fileObject, 1, 2);
@@ -91,7 +92,7 @@ public class GenericObjectTest {
   }
 
   @Test
-  public void testReadBufferPartial() throws IOException {
+  public void testReadBufferPartial() throws IOException, URISyntaxException {
     File f = createTempFile("hello");
     gov.nasa.arc.pds.xml.generated.File fileObject = getFileObject(f);
     GenericObject obj = new GenericObject(f.getParentFile(), fileObject, 1, 2);

--- a/src/test/java/gov/nasa/pds/objectAccess/TableReaderTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/TableReaderTest.java
@@ -253,6 +253,7 @@ public class TableReaderTest {
 
   private ProductObservational createProductLabel(ObjectAccess oa, String label) throws Exception {
     int cols = 2; // number of fields
+    int groups = 0; // number of groups
     int length = 11; // record length
     gov.nasa.arc.pds.xml.generated.File file = new gov.nasa.arc.pds.xml.generated.File();
     file.setFileName("CharTableReader.tab");
@@ -262,6 +263,7 @@ public class TableReaderTest {
     recLength.setValue(BigInteger.valueOf(length));
     record.setRecordLength(recLength);
     record.setFields(BigInteger.valueOf(cols));
+    record.setGroups(BigInteger.valueOf(groups));
 
     for (int i = 0; i < cols; i++) {
       String[] data = charData[0][i];
@@ -303,6 +305,7 @@ public class TableReaderTest {
   private ProductObservational createBinaryProductLabel(ObjectAccess oa, String label)
       throws Exception {
     int cols = 6;
+    int groups = 0;
 
     gov.nasa.arc.pds.xml.generated.File file = new gov.nasa.arc.pds.xml.generated.File();
     file.setFileName("BinaryTableReader.dat");
@@ -312,6 +315,7 @@ public class TableReaderTest {
     recLength.setValue(BigInteger.valueOf(28));
     record.setRecordLength(recLength);
     record.setFields(BigInteger.valueOf(cols));
+    record.setGroups(BigInteger.valueOf(groups));
 
     for (int i = 0; i < cols; i++) {
       String[] data = binData[0][i];

--- a/src/test/java/gov/nasa/pds/objectAccess/table/TableBinaryAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/TableBinaryAdapterTest.java
@@ -122,11 +122,16 @@ public class TableBinaryAdapterTest {
     group.setRepetitions(BigInteger.valueOf(2));
     group.setGroupLocation(getGroupLocation(8));
     group.setGroupLength(getGroupLength(8));
+    group.setFields(BigInteger.valueOf(1));
+    group.setGroups(BigInteger.valueOf(0));
 
     List<Object> groupFields = group.getFieldBinariesAndGroupFieldBinaries();
     groupFields.add(f4);
 
     RecordBinary rec = new RecordBinary();
+    rec.setFields(BigInteger.valueOf(2));
+    rec.setGroups(BigInteger.valueOf(1));
+
     List<Object> fields = rec.getFieldBinariesAndGroupFieldBinaries();
     fields.add(f1);
     fields.add(packedField);

--- a/src/test/resources/1000/Binary_Table_Test.xml
+++ b/src/test/resources/1000/Binary_Table_Test.xml
@@ -155,7 +155,7 @@
 
             <Record_Binary>
 
-                <fields>6</fields>
+                <fields>7</fields>
                 <groups>1</groups>
 
                 <record_length unit="byte">34</record_length>

--- a/src/test/resources/1000/Product_Table_Character.xml
+++ b/src/test/resources/1000/Product_Table_Character.xml
@@ -70,7 +70,7 @@
           <record_delimiter>carriage-return line-feed</record_delimiter>
           <Record_Character>
             <fields>10</fields>
-            <groups>1</groups>
+            <groups>0</groups>
             <record_length unit="byte">88</record_length>
             <Field_Character>
               <name>SOL</name>

--- a/src/test/resources/data_type_tests/BinaryIntegerTable.xml
+++ b/src/test/resources/data_type_tests/BinaryIntegerTable.xml
@@ -38,7 +38,7 @@
             <offset unit="byte">0</offset>
             <records>4</records>
             <Record_Binary>
-                <fields>4</fields>
+                <fields>14</fields>
                 <groups>0</groups>
                 <record_length unit="byte">58</record_length>
                 <Field_Binary>


### PR DESCRIPTION
Previous functionality hid a lot of metadata necessary in order to efficiently walk through data objects within a file, and validate each one individually.

Additionally, fixes numerous bugs and issues with existing code that was highlighted during testing.

Highlights include:
* New DataObjectLocation object
* Move RawTableReader from Validate to pds4-jparser
* Changes to API method to support passing of more metadata between objects

Refs NASA-PDS/validate#480
