### PR TITLE
Add the letter "s"

### DIFF
--- a/src/main/java/gov/nasa/pds/objectAccess/ImageExporter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/ImageExporter.java
@@ -239,9 +239,9 @@ public abstract class ImageExporter extends ObjectExporter {
     for (DisplaySettings ds : displaySettings) {
       if (ds.getLocalInternalReference() != null) {
         LocalInternalReference lir = ds.getLocalInternalReference();
-        if (lir.getLocalIdentifierReference() != null
-            && lir.getLocalIdentifierReference() instanceof Array) {
-          Array array = (Array) lir.getLocalIdentifierReference();
+        if (lir.getLocalIdentifierReferences() != null
+            && lir.getLocalIdentifierReferences() instanceof Array) {
+          Array array = (Array) lir.getLocalIdentifierReferences();
           if (id.equals(array.getLocalIdentifier())) {
             return ds;
           }


### PR DESCRIPTION
## 🗒️ Summary

The method name is actually `getLocalIdentifierReferences` with an `s`.

## ⚙️ Test Data and/or Report

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
```
<img width="476" alt="Three hours later" src="https://user-images.githubusercontent.com/814813/199829748-31f49f32-e09d-41af-b0c7-43cd94014900.png">

```
[INFO] Results:
[INFO] 
[INFO] Tests run: 672, Failures: 0, Errors: 0, Skipped: 0
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/validate/issues/544