### PR TITLE
Resolves validate#544

### DIFF
--- a/src/main/java/gov/nasa/pds/label/Label.java
+++ b/src/main/java/gov/nasa/pds/label/Label.java
@@ -665,7 +665,9 @@ public class Label {
     long offset = -1;
     if (stream instanceof EncodedByteStream) {
       EncodedByteStream ebs = (EncodedByteStream) stream;
-      size = ebs.getObjectLength().getValue().longValueExact();
+      if (ebs.getObjectLength() != null) {
+        size = ebs.getObjectLength().getValue().longValueExact();
+      }
       offset = ebs.getOffset().getValue().longValueExact();
     } else if (stream instanceof ParsableByteStream) {
       ParsableByteStream pbs = (ParsableByteStream) stream;


### PR DESCRIPTION
## 🗒️ Summary

Merge this and it might solve [validate#544](https://github.com/NASA-PDS/validate/issues/544). But I honestly have no idea if this is the correct way to do it.

Basically, it treats `EncodedByteStream`s the same way as `ParsableByteStream`s: the `object_length` is optional. See my comments on the "validate" issue for further analysis.

## ⚙️ Test Data and/or Report

```
[INFO] Scanning for projects...
```
<img width="413" alt="Three Hours Later from SpongeBob SquarePants" src="https://user-images.githubusercontent.com/814813/200399955-c20ace1b-325d-4cfd-a136-bb4d46b43be6.png">

```
[INFO] Tests run: 672, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.937 s - in TestSuite
…
[INFO] BUILD SUCCESS
```

## ♻️ Related Issues

- [validate#544](https://github.com/NASA-PDS/validate/issues/544)

