### PR TITLE
changes needed to support validate 519

### DIFF
--- a/src/main/java/gov/nasa/pds/label/object/TableRecord.java
+++ b/src/main/java/gov/nasa/pds/label/object/TableRecord.java
@@ -371,6 +371,11 @@ public interface TableRecord {
   void clear();
 
   /**
+   * @returns Length of the record in bytes.
+   */
+  int length();
+
+  /**
    * 
    * @return Gets the record location.
    */

--- a/src/main/java/gov/nasa/pds/objectAccess/ByteWiseFileAccessor.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/ByteWiseFileAccessor.java
@@ -190,10 +190,21 @@ public class ByteWiseFileAccessor implements Closeable {
       // if for whatever reason we don't read in sufficient bytes
       if (this.totalBytesRead < expectedBytesToRead) {
         if (expectedBytesToRead > fileSizeMinusOffset) {
+          if ((fileSizeMinusOffset / length) * length == fileSizeMinusOffset)
+            throw new InvalidTableException(
+                "Data object is truncated. Expected bytes as defined by label: " + expectedBytesToRead
+                    + " (" + records + " records times " + length + " bytes per record)" + ", Actual bytes in file: "
+                    + fileSizeMinusOffset + " (" + (fileSizeMinusOffset / length) + " records times " + length + " bytes per record)");
+          if ((fileSizeMinusOffset / records) * records == fileSizeMinusOffset)
+              throw new InvalidTableException(
+                      "Data object is truncated. Expected bytes as defined by label: " + expectedBytesToRead
+                          + " (" + records + " records times " + length + " bytes per record)" + ", Actual bytes in file: "
+                          + fileSizeMinusOffset + " (" + records + " records times " + (fileSizeMinusOffset/records) + " bytes per record)");
           throw new InvalidTableException(
-              "Data object is truncated. Expected bytes as defined by label: " + expectedBytesToRead
-                  + " (" + records + " records)" + ", Actual bytes remaining in file: "
-                  + fileSizeMinusOffset + " (" + (fileSizeMinusOffset / length) + " records)");
+                  "Data object is truncated. Expected bytes as defined by label: " + expectedBytesToRead
+                      + " (" + records + " records times " + length + " bytes per record)" + ", Actual bytes in file: "
+                      + fileSizeMinusOffset + " (" + ((float)(fileSizeMinusOffset) / (float)length) + " records times " + length + " bytes per record)"
+                      + " OR (" + records + " records times " + ((float)fileSizeMinusOffset / (float)records) + " bytes per record)");
         } else {
           throw new InvalidTableException("Expected to read in " + expectedBytesToRead
               + " bytes but only " + totalBytesRead + " bytes were read for " + url.toString());

--- a/src/main/java/gov/nasa/pds/objectAccess/DelimitedTableRecord.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/DelimitedTableRecord.java
@@ -86,6 +86,12 @@ public class DelimitedTableRecord implements TableRecord {
   }
 
   @Override
+  public int length() {
+	int len = 0;
+	for (String rv : this.recordValue) len += rv.length();
+	return len;
+  }
+  @Override
   public int findColumn(String name) {
     checkFieldName(name);
     return this.fieldMap.get(name);

--- a/src/main/java/gov/nasa/pds/objectAccess/FixedTableRecord.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/FixedTableRecord.java
@@ -107,6 +107,9 @@ public class FixedTableRecord implements TableRecord {
   }
 
   @Override
+  public int length() { return this.recordBytes.length; }
+
+  @Override
   public int findColumn(String name) {
     checkFieldName(name);
     return this.fieldMap.get(name);


### PR DESCRIPTION
## 🗒️ Summary
NASA-PDS/validate#519 required changes during the read process when tables do not have the correct number of bytes in a file. Also, adding a new check in validation required the TableRecord interface to be updated which, in turn, required implementers of the the interface to be updated.

## ⚙️ Test Data and/or Report
See NASA-PDS/validate#589

## ♻️ Related Issues
NASA-PDS/validate#519
