### PR TITLE
NASA-PDS/validate#593: check end of data not end of file

### DIFF
--- a/src/main/java/gov/nasa/pds/objectAccess/ByteWiseFileAccessor.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/ByteWiseFileAccessor.java
@@ -406,6 +406,10 @@ public class ByteWiseFileAccessor implements Closeable {
     return this.totalFileContentSize;
   }
 
+  public long getTotalBytesRead() {
+    return this.totalBytesRead;
+  }
+
   @Override
   public void close() throws IOException {
     LOGGER.debug("Closing ByteWiseFileAccessor");

--- a/src/main/java/gov/nasa/pds/objectAccess/RawTableReader.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/RawTableReader.java
@@ -185,7 +185,7 @@ public class RawTableReader extends TableReader {
 	int recordLength = this.getAdapter().getRecordLength();
 	long next_row = this.getCurrentRow() + 1;
 
-	if (0 <= this.accessor.getTotalFileContentSize() - (next_row * recordLength)) {
+	if (0 <= this.accessor.getTotalBytesRead() - (next_row * recordLength)) {
       line = this.accessor.readRecordBytes(next_row, 0, recordLength);
       this.setCurrentRow(next_row);
     }


### PR DESCRIPTION
## 🗒️ Summary
The number of bytes read for data processing is not the same as the size of the file. Changed check to see what is read for data not the whole file size.

## ⚙️ Test Data and/or Report
Validate regression checks pass.

## ♻️ Related Issues
NASA-PDS/validate#593