### PR TITLE
updated delimited table object length calculation using `max_record_length`

### DIFF
--- a/src/main/java/gov/nasa/pds/label/Label.java
+++ b/src/main/java/gov/nasa/pds/label/Label.java
@@ -78,6 +78,7 @@ import gov.nasa.arc.pds.xml.generated.ProductSPICEKernel;
 import gov.nasa.arc.pds.xml.generated.ProductService;
 import gov.nasa.arc.pds.xml.generated.ProductThumbnail;
 import gov.nasa.arc.pds.xml.generated.ProductXMLSchema;
+import gov.nasa.arc.pds.xml.generated.RecordDelimited;
 import gov.nasa.arc.pds.xml.generated.ServiceDescription;
 import gov.nasa.arc.pds.xml.generated.TableBinary;
 import gov.nasa.arc.pds.xml.generated.TableCharacter;
@@ -647,7 +648,12 @@ public class Label {
       offset = table.getOffset().getValue().longValueExact();
     }
     long size = -1;
-    if (file.getFileSize() != null) {
+    if (table.getRecordDelimited() != null) {
+      RecordDelimited definition = table.getRecordDelimited();
+      if (definition.getMaximumRecordLength() != null) {
+        size = definition.getMaximumRecordLength().getValue().longValue() * table.getRecords().longValue();
+      }
+    } else if (file.getFileSize() != null) {
       size = file.getFileSize().getValue().longValue() - offset;
     }
     return new TableObject(parentDir, file, table, offset, size, location);

--- a/src/main/java/gov/nasa/pds/label/Label.java
+++ b/src/main/java/gov/nasa/pds/label/Label.java
@@ -652,6 +652,8 @@ public class Label {
       RecordDelimited definition = table.getRecordDelimited();
       if (definition.getMaximumRecordLength() != null) {
         size = definition.getMaximumRecordLength().getValue().longValue() * table.getRecords().longValue();
+      } else if (file.getFileSize() != null) {
+        size = file.getFileSize().getValue().longValue() - offset;
       }
     } else if (file.getFileSize() != null) {
       size = file.getFileSize().getValue().longValue() - offset;

--- a/src/main/java/gov/nasa/pds/label/object/DataObject.java
+++ b/src/main/java/gov/nasa/pds/label/object/DataObject.java
@@ -61,7 +61,7 @@ public abstract class DataObject {
   protected URL parentDir;
   protected gov.nasa.arc.pds.xml.generated.File fileObject;
   protected long offset;
-  protected long size;
+  private long size;
   protected String name;
   protected String localIdentifier;
   protected SeekableByteChannel channel;


### PR DESCRIPTION
## 🗒️ Summary
The current code erroneously assumed one table per file and thus computes the size incorrectly. Modified to compute the size of the table rather than use the file size.

## ⚙️ Test Data and/or Report
See NASA-PDS/validate#616 unit test

## ♻️ Related Issues
Closes NASA-PDS/validate#616

