### PR TITLE
Bug fix for checking tables that define an object_length

### DIFF
--- a/src/main/java/gov/nasa/pds/label/Label.java
+++ b/src/main/java/gov/nasa/pds/label/Label.java
@@ -652,9 +652,13 @@ public class Label {
       RecordDelimited definition = table.getRecordDelimited();
       if (definition.getMaximumRecordLength() != null) {
         size = definition.getMaximumRecordLength().getValue().longValue() * table.getRecords().longValue();
+      } else if (table.getObjectLength() != null) {
+        size = table.getObjectLength().getValue().longValueExact();
       } else if (file.getFileSize() != null) {
         size = file.getFileSize().getValue().longValue() - offset;
       }
+    } else if (table.getObjectLength() != null) {
+      size = table.getObjectLength().getValue().longValueExact();
     } else if (file.getFileSize() != null) {
       size = file.getFileSize().getValue().longValue() - offset;
     }


### PR DESCRIPTION
## 🗒️ Summary
Simple change to use the object length when present over file size

## ⚙️ Test Data and/or Report
See unit test in NASA-PDS/validate#687

## ♻️ Related Issues
See NASA-PDS/validate#684