### PR TITLE
Update jparser to handle missing `object_length` in delimited tables

### DIFF
--- a/src/main/java/gov/nasa/pds/label/Label.java
+++ b/src/main/java/gov/nasa/pds/label/Label.java
@@ -655,7 +655,7 @@ public class Label {
       } else if (table.getObjectLength() != null) {
         size = table.getObjectLength().getValue().longValueExact();
       } else if (file.getFileSize() != null) {
-        size = file.getFileSize().getValue().longValue() - offset;
+        size = 0;//file.getFileSize().getValue().longValue() - offset;
       }
     } else if (table.getObjectLength() != null) {
       size = table.getObjectLength().getValue().longValueExact();

--- a/src/main/java/gov/nasa/pds/label/Label.java
+++ b/src/main/java/gov/nasa/pds/label/Label.java
@@ -655,7 +655,7 @@ public class Label {
       } else if (table.getObjectLength() != null) {
         size = table.getObjectLength().getValue().longValueExact();
       } else if (file.getFileSize() != null) {
-        size = 0;//file.getFileSize().getValue().longValue() - offset;
+        size = 0;
       }
     } else if (table.getObjectLength() != null) {
       size = table.getObjectLength().getValue().longValueExact();


### PR DESCRIPTION
## 🗒️ Summary
Default for delimited table size when nothing is given was file size. Changed to 0. Basically, we just punt this metadata check and allow content validation to catch any issues in the table definitions.

## ⚙️ Test Data and/or Report
All NASA-PDS/validate#783 automate unit tests should pass

## ♻️ Related Issues
NASA-PDS/validate#781