### PR TITLE
Use BigInteger instead of Integer as heavy lifter for data typing

### DIFF
--- a/src/main/java/gov/nasa/pds/objectAccess/table/BitFieldAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/BitFieldAdapter.java
@@ -188,16 +188,10 @@ public class BitFieldAdapter implements FieldAdapter {
     }
 
     int startByte = startBit / Byte.SIZE;
-    int stopByte = stopBit / Byte.SIZE;
 
     // hint: startBit & Byte.SIZE-1 == startBit & Byte.Size but can be faster
     long bytesValue = getBytesAsLong(b, offset+startByte, startBit & (Byte.SIZE-1), stopBit - startBit + 1);
-
-    // Now shift right to get rid of the extra bits.
-    int extraRightBits = (stopByte + 1) * Byte.SIZE - stopBit - 1;
-    long shiftedValue = bytesValue >> extraRightBits;
-
-    return rightmostBits(shiftedValue, stopBit - startBit + 1, isSigned);
+    return rightmostBits(bytesValue, stopBit - startBit + 1, isSigned);
   }
 
   // Default scope, for unit testing.
@@ -220,12 +214,13 @@ public class BitFieldAdapter implements FieldAdapter {
   }
 
   static long getBytesAsLong(byte[] source, int startByte, int firstBitOffset, int numOfBits) {
+    int offset = firstBitOffset;
     StringBuffer bitPattern = new StringBuffer();
     for (int bit = 0 ; bit < numOfBits ; bit++) {
       byte byt = source[startByte + (bit+firstBitOffset)/8];
-      int offset = (bit + firstBitOffset) & (Byte.SIZE-1); // modulo Byte.SIZE but quicker
       boolean zero = (byt & (1<<(7-offset))) == 0;
       bitPattern.append(zero ? "0" : "1");
+      offset = (offset + 1) & (Byte.SIZE-1); // modulo Byte.SIZE but quicker
     }
     return new BigInteger(bitPattern.toString(), 2).longValue();
   }

--- a/src/main/java/gov/nasa/pds/objectAccess/table/BitFieldAdapter.java
+++ b/src/main/java/gov/nasa/pds/objectAccess/table/BitFieldAdapter.java
@@ -222,9 +222,9 @@ public class BitFieldAdapter implements FieldAdapter {
   static long getBytesAsLong(byte[] source, int startByte, int firstBitOffset, int numOfBits) {
     StringBuffer bitPattern = new StringBuffer();
     for (int bit = 0 ; bit < numOfBits ; bit++) {
-      byte b = source[startByte + (bit+firstBitOffset)/8];
-      int offset = (b + firstBitOffset) & (Byte.SIZE-1); // modulo Byte.SIZE but quicker
-      boolean zero = (b & (1<<offset)) == 0;
+      byte byt = source[startByte + (bit+firstBitOffset)/8];
+      int offset = (bit + firstBitOffset) & (Byte.SIZE-1); // modulo Byte.SIZE but quicker
+      boolean zero = (byt & (1<<(7-offset))) == 0;
       bitPattern.append(zero ? "0" : "1");
     }
     return new BigInteger(bitPattern.toString(), 2).longValue();

--- a/src/test/java/gov/nasa/pds/objectAccess/table/BitFieldAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/BitFieldAdapterTest.java
@@ -237,7 +237,7 @@ public class BitFieldAdapterTest {
   @Test(dataProvider = "bytesAsLongTests")
   public void testGetbytesAsLong(byte[] buf, int off, int len, int startByte, int stopByte,
       long expected) {
-    assertEquals(BitFieldAdapter.getBytesAsLong(buf, off, startByte, stopByte), expected);
+    assertEquals(BitFieldAdapter.getBytesAsLong(buf, off + startByte, 0, len*Byte.SIZE), expected);
   }
 
   @SuppressWarnings("unused")

--- a/src/test/java/gov/nasa/pds/objectAccess/table/BitFieldAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/BitFieldAdapterTest.java
@@ -237,7 +237,7 @@ public class BitFieldAdapterTest {
   @Test(dataProvider = "bytesAsLongTests")
   public void testGetbytesAsLong(byte[] buf, int off, int len, int startByte, int stopByte,
       long expected) {
-    assertEquals(BitFieldAdapter.getBytesAsLong(buf, off + startByte, 0, len*Byte.SIZE), expected);
+    assertEquals(BitFieldAdapter.getBytesAsLong(buf, off + startByte, 0, (stopByte - startByte + 1)*Byte.SIZE), expected);
   }
 
   @SuppressWarnings("unused")

--- a/src/test/java/gov/nasa/pds/objectAccess/table/BitFieldAdapterTest.java
+++ b/src/test/java/gov/nasa/pds/objectAccess/table/BitFieldAdapterTest.java
@@ -175,12 +175,6 @@ public class BitFieldAdapterTest {
     adapter.getLong(b, 0, b.length, 0, Long.SIZE);
   }
 
-  @Test(expectedExceptions = {NumberFormatException.class})
-  public void testBitFieldSpansMoreThanLong() {
-    byte[] b = new byte[9];
-    adapter.getLong(b, 0, b.length, 1, Long.SIZE);
-  }
-
   @Test(dataProvider = "rightmostBitsTests")
   public void testRightmostBits(long value, int nBits, long expected) {
     assertEquals(BitFieldAdapter.rightmostBits(value, nBits, false), expected);


### PR DESCRIPTION
## 🗒️ Summary
Instead of using Long as heavy lifter for bit conversion, use BigInteger.

## ⚙️ Test Data and/or Report
See automated testing below as this function already has UTs.

## ♻️ Related Issues
NASA-PDS/validate#919 - not a complete fix but the necessary code changes.