### PR TITLE
Upgrade opencsv, removing critical security vulnerability

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2,6 +2,9 @@
   "version": "1.4.0",
   "plugins_used": [
     {
+      "name": "AbsolutePathDetectorExperimental"
+    },
+    {
       "name": "ArtifactoryDetector"
     },
     {
@@ -85,6 +88,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -132,7 +139,8 @@
         "filename": "pom.xml",
         "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
         "is_verified": false,
-        "line_number": 257
+        "line_number": 218,
+        "is_secret": false
       }
     ],
     "src/changes/changes.xml": [
@@ -141,7 +149,8 @@
         "filename": "src/changes/changes.xml",
         "hashed_secret": "1ac7d6deddaec3bd29b1f559a573231d20d764fd",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 38,
+        "is_secret": false
       }
     ],
     "src/site/xdoc/develop/index.xml.vm": [
@@ -150,14 +159,16 @@
         "filename": "src/site/xdoc/develop/index.xml.vm",
         "hashed_secret": "bf1bfc3f1f5b1a63361b4c29a798ea62be348864",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 38,
+        "is_secret": false
       },
       {
         "type": "Email Address",
         "filename": "src/site/xdoc/develop/index.xml.vm",
         "hashed_secret": "1ac7d6deddaec3bd29b1f559a573231d20d764fd",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 39,
+        "is_secret": false
       }
     ],
     "src/site/xdoc/index.xml": [
@@ -166,14 +177,16 @@
         "filename": "src/site/xdoc/index.xml",
         "hashed_secret": "1ac7d6deddaec3bd29b1f559a573231d20d764fd",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 37,
+        "is_secret": false
       },
       {
         "type": "Email Address",
         "filename": "src/site/xdoc/index.xml",
         "hashed_secret": "3a6d7aa49a8e4a2fe32a5cd0e53da9cb96bd8d29",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 45,
+        "is_secret": false
       }
     ],
     "src/site/xdoc/install/index-win.xml.vm": [
@@ -182,14 +195,16 @@
         "filename": "src/site/xdoc/install/index-win.xml.vm",
         "hashed_secret": "bf1bfc3f1f5b1a63361b4c29a798ea62be348864",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 38,
+        "is_secret": false
       },
       {
         "type": "Email Address",
         "filename": "src/site/xdoc/install/index-win.xml.vm",
         "hashed_secret": "1ac7d6deddaec3bd29b1f559a573231d20d764fd",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 39,
+        "is_secret": false
       }
     ],
     "src/site/xdoc/install/index.xml.vm": [
@@ -198,7 +213,8 @@
         "filename": "src/site/xdoc/install/index.xml.vm",
         "hashed_secret": "1ac7d6deddaec3bd29b1f559a573231d20d764fd",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 38,
+        "is_secret": false
       }
     ],
     "src/site/xdoc/operate/index.xml.vm": [
@@ -207,14 +223,16 @@
         "filename": "src/site/xdoc/operate/index.xml.vm",
         "hashed_secret": "bf1bfc3f1f5b1a63361b4c29a798ea62be348864",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 38,
+        "is_secret": false
       },
       {
         "type": "Email Address",
         "filename": "src/site/xdoc/operate/index.xml.vm",
         "hashed_secret": "1ac7d6deddaec3bd29b1f559a573231d20d764fd",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 39,
+        "is_secret": false
       }
     ],
     "src/test/java/gov/nasa/pds/objectAccess/example/ExtractTableTest.java": [
@@ -223,7 +241,8 @@
         "filename": "src/test/java/gov/nasa/pds/objectAccess/example/ExtractTableTest.java",
         "hashed_secret": "b30c2130e7a42f7762d5e7582d94c4ea45d1de9c",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 128,
+        "is_secret": false
       }
     ],
     "src/test/resources/pds_dictionary/pdsdd.full": [
@@ -232,9 +251,10 @@
         "filename": "src/test/resources/pds_dictionary/pdsdd.full",
         "hashed_secret": "a5b4ee58fbd830f6a52d58dc786bc92aebb0c091",
         "is_verified": false,
-        "line_number": 25195
+        "line_number": 25195,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2023-11-17T21:16:18Z"
+  "generated_at": "2024-09-26T21:41:45Z"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
     <dependency>
       <groupId>gov.nasa.pds</groupId>
       <artifactId>opencsv</artifactId>
-      <version>5.4-SNAPSHOT</version>
+      <version>5.5-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>gov.nasa.gsfc.heasarc</groupId>


### PR DESCRIPTION
## 🗒️ Summary

Upgrades dependency on pds-opencsv in order to avoid critical security vulnerability.

## ⚙️ Test Data and/or Report
```
$ mvn test
[INFO] Scanning for projects...
…
[INFO] Tests run: 673, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20.539 s
[INFO] Finished at: 2024-09-26T16:43:10-05:00
[INFO] ------------------------------------------------------------------------
```

## ♻️ Related Issues

- [devops#76](https://github.com/NASA-PDS/devops/issues/76)