### PR TITLE
Bundle local repository dependencies using Maven Shade Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@
 *.javac
 .gwt/
 target/
+dependency-reduced-pom.xml
 
 # macOS specific stuff
 .DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,39 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <!-- Only include local repo dependencies that cause issues for downstream projects -->
+              <artifactSet>
+                <includes>
+                  <include>gov.nasa.pds:vicario</include>
+                  <include>gov.nasa.pds:opencsv</include>
+                </includes>
+              </artifactSet>
+              <!-- Keep dependency-reduced POM clean -->
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <!-- Preserve existing manifest entries -->
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Use Maven Shade Plugin to embed vicario and opencsv dependencies directly into the pds4-jparser JAR file.

Previously, these dependencies were only available in the local 'repo/' directory, requiring downstream projects to configure the local repository in their pom.xml. This approach was not scalable and caused dependency resolution issues.

NOTE: Shaded JAR increases from 501KB to 1.4MB (~900KB for both dependencies)

## ⚙️ Test Data and/or Report
See github actions

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
- Refs NASA-PDS/software-issues-repo#141